### PR TITLE
Refactor: extract shared utilities, fix bugs, add favicon

### DIFF
--- a/index.html
+++ b/index.html
@@ -2,7 +2,7 @@
 <html lang="en">
   <head>
     <meta charset="UTF-8" />
-    <link rel="icon" type="image/svg+xml" href="/vite.svg" />
+    <link rel="icon" type="image/svg+xml" href="/f1hub.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Formula1 Hub</title>
   </head>

--- a/public/f1hub.svg
+++ b/public/f1hub.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <rect width="32" height="32" fill="#080A0F"/>
+  <rect x="1" y="1" width="30" height="30" fill="none" stroke="#DC0000" stroke-width="1" opacity="0.6"/>
+  <text x="16" y="22" font-family="monospace" font-weight="bold" font-size="14" fill="#DC0000" text-anchor="middle">F1</text>
+</svg>

--- a/src/api/f1Service.js
+++ b/src/api/f1Service.js
@@ -1,485 +1,176 @@
 import axios from "axios";
 
-// Determine if we're in development or production
 const isDevelopment =
   window.location.hostname === "localhost" ||
   window.location.hostname === "127.0.0.1";
 
-// Use Jolpica API for both development and production
-// This is because Ergast doesn't have 2025 data yet
 const JOLPICA_BASE_URL = isDevelopment
-  ? "https://api.jolpi.ca/ergast" // Use Jolpica directly in development (correct URL)
-  : "/api/jolpica"; // Use proxy in production
+  ? "https://api.jolpi.ca/ergast"
+  : "/api/jolpica";
 
-console.log(
-  `Using API base URL: ${JOLPICA_BASE_URL} (isDevelopment: ${isDevelopment})`
-);
+const jolpicaInstance = axios.create({ baseURL: JOLPICA_BASE_URL });
 
-const jolpicaInstance = axios.create({
-  baseURL: JOLPICA_BASE_URL,
+const currentYear = () => new Date().getFullYear();
+
+// If the requested season has no data and it's the current year, try the previous year.
+const withYearFallback = (fn, season) => {
+  if (season === currentYear()) return fn(season - 1);
+  return Promise.resolve("No Data Fetched");
+};
+
+const transformRace = (race, timestamp) => ({
+  season: parseInt(race.season),
+  round: parseInt(race.round),
+  raceName: race.raceName,
+  date: race.date,
+  time: race.time,
+  Circuit: {
+    circuitId: race.Circuit.circuitId,
+    circuitName: race.Circuit.circuitName,
+    Location: {
+      locality: race.Circuit.Location.locality,
+      country: race.Circuit.Location.country,
+    },
+  },
+  _timestamp: timestamp,
 });
 
-// Fetch driver standings from Jolpica API
-export const getDriverStandings = async (season = new Date().getFullYear()) => {
-  try {
-    console.log(
-      `Fetching driver standings from Jolpica API for season ${season}`
-    );
-    const timestamp = new Date().getTime();
+const transformStanding = (standing, season, timestamp) => ({
+  position: parseInt(standing.position),
+  points: parseFloat(standing.points),
+  wins: parseInt(standing.wins),
+  Driver: {
+    driverId: standing.Driver.driverId,
+    givenName: standing.Driver.givenName,
+    familyName: standing.Driver.familyName,
+    nationality: standing.Driver.nationality,
+  },
+  Constructor: {
+    constructorId: standing.Constructors[0].constructorId,
+    name: standing.Constructors[0].name,
+  },
+  season,
+  _timestamp: timestamp,
+});
 
-    // Use the Ergast-compatible endpoint format
+export const getDriverStandings = async (season = currentYear()) => {
+  try {
+    const timestamp = Date.now();
     const response = await jolpicaInstance.get(
       `f1/${season}/driverStandings.json`
     );
-
-    console.log(
-      "Jolpica API response:",
-      JSON.stringify(response.data, null, 2)
-    );
-
-    if (
-      response.data &&
-      response.data.MRData &&
-      response.data.MRData.StandingsTable &&
-      response.data.MRData.StandingsTable.StandingsLists &&
-      response.data.MRData.StandingsTable.StandingsLists.length > 0
-    ) {
-      const standingsList =
-        response.data.MRData.StandingsTable.StandingsLists[0];
-      const driverStandings = standingsList.DriverStandings;
-
-      console.log(
-        `Successfully fetched ${driverStandings.length} driver standings from Jolpica API`
-      );
-      console.log(
-        "First driver standing:",
-        JSON.stringify(driverStandings[0], null, 2)
-      );
-
-      // Transform to match our expected format
-      const mappedStandings = driverStandings.map((standing) => ({
-        position: parseInt(standing.position),
-        points: parseFloat(standing.points),
-        wins: parseInt(standing.wins),
-        Driver: {
-          driverId: standing.Driver.driverId,
-          givenName: standing.Driver.givenName,
-          familyName: standing.Driver.familyName,
-          nationality: standing.Driver.nationality,
-        },
-        Constructor: {
-          constructorId: standing.Constructors[0].constructorId,
-          name: standing.Constructors[0].name,
-        },
-        season: season,
-        _timestamp: timestamp,
-      }));
-
-      console.log(
-        "Mapped standings:",
-        JSON.stringify(mappedStandings[0], null, 2)
-      );
-      return mappedStandings;
-    } else {
-      console.log("No driver standings data found in Jolpica API response");
-
-      // Try previous season if we're looking at current year
-      if (season === new Date().getFullYear()) {
-        console.log("Trying previous season");
-        const previousYear = season - 1;
-        return await getDriverStandings(previousYear);
-      } else {
-        console.log("No data available");
-        return "No Data Fetched";
-      }
+    const standings =
+      response.data?.MRData?.StandingsTable?.StandingsLists?.[0]
+        ?.DriverStandings;
+    if (standings?.length > 0) {
+      return standings.map((s) => transformStanding(s, season, timestamp));
     }
-  } catch (error) {
-    console.error("Error fetching driver standings from Jolpica API:", error);
-
-    // Try previous season if we're looking at current year
-    if (season === new Date().getFullYear()) {
-      console.log("Error occurred, trying previous season");
-      const previousYear = season - 1;
-      try {
-        return await getDriverStandings(previousYear);
-      } catch (prevYearError) {
-        console.error("Error fetching previous season data:", prevYearError);
-        console.log("No data available");
-        return "No Data Fetched";
-      }
-    } else {
-      console.log("No data available");
-      return "No Data Fetched";
-    }
+    return withYearFallback(getDriverStandings, season);
+  } catch {
+    return withYearFallback(getDriverStandings, season);
   }
 };
 
-// Fetch race schedule from Jolpica API
-export const getRaceSchedule = async (
-  season = new Date().getFullYear(),
-  allowFallback = true
-) => {
+// Tries axios first, then iterates through fallback URLs (proxy → direct).
+const fetchRaceScheduleRaw = async (season) => {
+  const timestamp = Date.now();
+
   try {
-    console.log(`Fetching race schedule from Jolpica API for season ${season}`);
-    console.log(`API URL: ${JOLPICA_BASE_URL}/f1/${season}.json`);
-    console.log(`Environment: ${isDevelopment ? "Development" : "Production"}`);
-
-    // For debugging in Vercel
-    if (!isDevelopment) {
-      console.log(
-        `Full URL in production: ${window.location.origin}/api/jolpica/f1/${season}.json`
-      );
+    const response = await jolpicaInstance.get(`f1/${season}.json`);
+    const races = response.data?.MRData?.RaceTable?.Races;
+    if (races?.length > 0) {
+      return races.map((r) => transformRace(r, timestamp));
     }
+  } catch (_) {}
 
-    const timestamp = new Date().getTime();
+  const fallbackUrls = isDevelopment
+    ? [`https://api.jolpi.ca/ergast/f1/${season}.json`]
+    : [
+        `${window.location.origin}/api/jolpica/f1/${season}.json`,
+        `https://api.jolpi.ca/ergast/f1/${season}.json`,
+      ];
 
-    // Try with axios first
+  for (const url of fallbackUrls) {
     try {
-      const response = await jolpicaInstance.get(`f1/${season}.json`);
-      console.log(
-        "Race schedule API response with axios:",
-        response.status,
-        response.statusText
-      );
-
-      if (
-        response.data &&
-        response.data.MRData &&
-        response.data.MRData.RaceTable &&
-        response.data.MRData.RaceTable.Races &&
-        response.data.MRData.RaceTable.Races.length > 0
-      ) {
-        const races = response.data.MRData.RaceTable.Races;
-
-        console.log(
-          `Successfully fetched ${races.length} races for season ${season}`
-        );
-
-        // Log the first race to see its structure
-        console.log(
-          "First race data structure:",
-          JSON.stringify(races[0], null, 2)
-        );
-
-        // Transform to match our expected format
-        const transformedRaces = races.map((race) => ({
-          season: parseInt(race.season),
-          round: parseInt(race.round),
-          raceName: race.raceName,
-          date: race.date,
-          time: race.time,
-          Circuit: {
-            circuitId: race.Circuit.circuitId,
-            circuitName: race.Circuit.circuitName,
-            Location: {
-              locality: race.Circuit.Location.locality,
-              country: race.Circuit.Location.country,
-            },
-          },
-          _timestamp: timestamp,
-        }));
-
-        // Log the first transformed race
-        console.log(
-          "First transformed race:",
-          JSON.stringify(transformedRaces[0], null, 2)
-        );
-
-        return transformedRaces;
+      const res = await fetch(url);
+      if (!res.ok) continue;
+      const data = await res.json();
+      const races = data?.MRData?.RaceTable?.Races;
+      if (races?.length > 0) {
+        return races.map((r) => transformRace(r, timestamp));
       }
-    } catch (axiosError) {
-      console.log(
-        "Axios approach failed, trying fetch API:",
-        axiosError.message
-      );
-    }
+    } catch (_) {}
+  }
 
-    // If axios fails, try with fetch as a fallback
-    console.log("Trying with fetch API as fallback");
+  return null;
+};
 
-    // Use direct Jolpica URL for development, proxied URL for production
-    let directUrl;
-    if (isDevelopment) {
-      directUrl = `https://api.jolpi.ca/ergast/f1/${season}.json`;
-    } else {
-      // In production, try both the proxy and direct URL
-      try {
-        // First try with the proxy
-        directUrl = `${window.location.origin}/api/jolpica/f1/${season}.json`;
-        console.log(`Trying production proxy URL: ${directUrl}`);
-
-        const proxyResponse = await fetch(directUrl);
-        if (proxyResponse.ok) {
-          const responseData = await proxyResponse.json();
-          console.log(
-            "Race schedule API response with fetch (proxy):",
-            proxyResponse.status
-          );
-
-          if (
-            responseData &&
-            responseData.MRData &&
-            responseData.MRData.RaceTable &&
-            responseData.MRData.RaceTable.Races &&
-            responseData.MRData.RaceTable.Races.length > 0
-          ) {
-            const races = responseData.MRData.RaceTable.Races;
-            console.log(
-              `Successfully fetched ${races.length} races with proxy`
-            );
-
-            // Transform to match our expected format
-            const transformedRaces = races.map((race) => ({
-              season: parseInt(race.season),
-              round: parseInt(race.round),
-              raceName: race.raceName,
-              date: race.date,
-              time: race.time,
-              Circuit: {
-                circuitId: race.Circuit.circuitId,
-                circuitName: race.Circuit.circuitName,
-                Location: {
-                  locality: race.Circuit.Location.locality,
-                  country: race.Circuit.Location.country,
-                },
-              },
-              _timestamp: timestamp,
-            }));
-
-            return transformedRaces;
-          }
-        }
-
-        // If proxy fails, try direct URL as last resort
-        console.log("Proxy approach failed, trying direct URL as last resort");
-        directUrl = `https://api.jolpi.ca/ergast/f1/${season}.json`;
-      } catch (proxyError) {
-        console.log("Error with proxy approach:", proxyError.message);
-        directUrl = `https://api.jolpi.ca/ergast/f1/${season}.json`;
-      }
-    }
-
-    console.log(`Direct URL: ${directUrl}`);
-
-    const fetchResponse = await fetch(directUrl);
-    if (!fetchResponse.ok) {
-      throw new Error(`HTTP error! status: ${fetchResponse.status}`);
-    }
-
-    const responseData = await fetchResponse.json();
-    console.log(
-      "Race schedule API response with fetch:",
-      fetchResponse.status,
-      fetchResponse.statusText
-    );
-
-    if (
-      responseData &&
-      responseData.MRData &&
-      responseData.MRData.RaceTable &&
-      responseData.MRData.RaceTable.Races &&
-      responseData.MRData.RaceTable.Races.length > 0
-    ) {
-      const races = responseData.MRData.RaceTable.Races;
-
-      console.log(
-        `Successfully fetched ${races.length} races for season ${season} with fetch`
-      );
-
-      // Log the first race to see its structure
-      console.log(
-        "First race data structure (fetch):",
-        JSON.stringify(races[0], null, 2)
-      );
-
-      // Transform to match our expected format
-      const transformedRaces = races.map((race) => ({
-        season: parseInt(race.season),
-        round: parseInt(race.round),
-        raceName: race.raceName,
-        date: race.date,
-        time: race.time,
-        Circuit: {
-          circuitId: race.Circuit.circuitId,
-          circuitName: race.Circuit.circuitName,
-          Location: {
-            locality: race.Circuit.Location.locality,
-            country: race.Circuit.Location.country,
-          },
-        },
-        _timestamp: timestamp,
-      }));
-
-      // Log the first transformed race
-      console.log(
-        "First transformed race (fetch):",
-        JSON.stringify(transformedRaces[0], null, 2)
-      );
-
-      return transformedRaces;
-    } else {
-      console.log("No race schedule data found in API response");
-
-      // Try previous season if we're looking at current year and fallback is allowed
-      if (allowFallback && season === new Date().getFullYear()) {
-        console.log("Trying previous season");
-        const previousYear = season - 1;
-        return await getRaceSchedule(previousYear, allowFallback);
-      } else {
-        return "No Data Fetched";
-      }
-    }
-  } catch (error) {
-    console.error("Error fetching race schedule:", error);
-    console.error("Error details:", {
-      message: error.message,
-      status: error.response?.status,
-      statusText: error.response?.statusText,
-      url: `${JOLPICA_BASE_URL}/f1/${season}.json`,
-      data: error.response?.data,
-    });
-
-    // Try previous season if we're looking at current year and fallback is allowed
-    if (allowFallback && season === new Date().getFullYear()) {
-      console.log("Error occurred, trying previous season");
-      const previousYear = season - 1;
-      try {
-        return await getRaceSchedule(previousYear, allowFallback);
-      } catch (prevYearError) {
-        console.error("Error fetching previous season data:", prevYearError);
-        console.log("No data available");
-        return "No Data Fetched";
-      }
-    } else {
-      console.log("No data available");
-      return "No Data Fetched";
-    }
+export const getRaceSchedule = async (season = currentYear()) => {
+  try {
+    const races = await fetchRaceScheduleRaw(season);
+    if (races) return races;
+    return withYearFallback(getRaceSchedule, season);
+  } catch {
+    return withYearFallback(getRaceSchedule, season);
   }
 };
 
-// Fetch last race results from Jolpica API
-export const getLastRaceResults = async (season = new Date().getFullYear()) => {
+export const getLastRaceResults = async (season = currentYear()) => {
   try {
-    console.log(
-      `Fetching last race results from Jolpica API for season ${season}`
+    const timestamp = Date.now();
+    // `last` returns the most recently completed race, not just the last scheduled one
+    const resultsRes = await jolpicaInstance.get(
+      `f1/${season}/last/results.json`
     );
-    const timestamp = new Date().getTime();
+    const race = resultsRes.data?.MRData?.RaceTable?.Races?.[0];
+    if (!race?.Results?.length)
+      return withYearFallback(getLastRaceResults, season);
 
-    // First get the last round number for the season
-    const seasonsResponse = await jolpicaInstance.get(`f1/${season}.json`);
-
-    if (
-      seasonsResponse.data &&
-      seasonsResponse.data.MRData &&
-      seasonsResponse.data.MRData.RaceTable &&
-      seasonsResponse.data.MRData.RaceTable.Races &&
-      seasonsResponse.data.MRData.RaceTable.Races.length > 0
-    ) {
-      const races = seasonsResponse.data.MRData.RaceTable.Races;
-      const lastRaceRound = races[races.length - 1].round;
-
-      console.log(
-        `Found last race round: ${lastRaceRound} for season ${season}`
-      );
-
-      // Now get the results for this race
-      const resultsResponse = await jolpicaInstance.get(
-        `f1/${season}/${lastRaceRound}/results.json`
-      );
-
-      if (
-        resultsResponse.data &&
-        resultsResponse.data.MRData &&
-        resultsResponse.data.MRData.RaceTable &&
-        resultsResponse.data.MRData.RaceTable.Races &&
-        resultsResponse.data.MRData.RaceTable.Races.length > 0
-      ) {
-        const race = resultsResponse.data.MRData.RaceTable.Races[0];
-        const results = race.Results;
-
-        console.log(
-          `Successfully fetched ${results.length} results for ${race.raceName}`
-        );
-
-        return {
-          season: parseInt(race.season),
-          round: parseInt(race.round),
-          raceName: race.raceName,
-          date: race.date,
-          Circuit: {
-            circuitId: race.Circuit.circuitId,
-            circuitName: race.Circuit.circuitName,
-            Location: {
-              locality: race.Circuit.Location.locality,
-              country: race.Circuit.Location.country,
-            },
-          },
-          results: results.map((result) => ({
-            position: result.position,
-            Driver: {
-              givenName: result.Driver.givenName,
-              familyName: result.Driver.familyName,
-              code: result.Driver.code,
-            },
-            Constructor: {
-              name: result.Constructor.name,
-            },
-            grid: result.grid,
-            laps: result.laps,
-            status: result.status,
-            Time: result.Time ? { time: result.Time.time } : null,
-            FastestLap: result.FastestLap
-              ? {
-                  rank: result.FastestLap.rank,
-                  lap: result.FastestLap.lap,
-                  Time: result.FastestLap.Time
-                    ? { time: result.FastestLap.Time.time }
-                    : null,
-                  AverageSpeed: result.FastestLap.AverageSpeed
-                    ? {
-                        speed: result.FastestLap.AverageSpeed.speed,
-                        units: result.FastestLap.AverageSpeed.units,
-                      }
-                    : null,
-                }
-              : null,
-            points: result.points,
-          })),
-          _timestamp: timestamp,
-        };
-      } else {
-        console.log("No race results found in Jolpica API response");
-      }
-    } else {
-      console.log("No races found for season in Jolpica API response");
-    }
-
-    // If we get here, try previous season if we're looking at current year
-    if (season === new Date().getFullYear()) {
-      console.log("No current season data found, trying previous season");
-      const previousYear = season - 1;
-      return await getLastRaceResults(previousYear);
-    } else {
-      console.log("No data available for season", season);
-      return "No Data Fetched";
-    }
-  } catch (error) {
-    console.error("Error fetching last race results from Jolpica API:", error);
-
-    // Try previous season if we're looking at current year
-    if (season === new Date().getFullYear()) {
-      console.log("Error occurred, trying previous season");
-      const previousYear = season - 1;
-      try {
-        return await getLastRaceResults(previousYear);
-      } catch (prevYearError) {
-        console.error("Error fetching previous season data:", prevYearError);
-        console.log("No data available");
-        return "No Data Fetched";
-      }
-    } else {
-      console.log("No data available");
-      return "No Data Fetched";
-    }
+    return {
+      season: parseInt(race.season),
+      round: parseInt(race.round),
+      raceName: race.raceName,
+      date: race.date,
+      Circuit: {
+        circuitId: race.Circuit.circuitId,
+        circuitName: race.Circuit.circuitName,
+        Location: {
+          locality: race.Circuit.Location.locality,
+          country: race.Circuit.Location.country,
+        },
+      },
+      results: race.Results.map((result) => ({
+        position: result.position,
+        Driver: {
+          givenName: result.Driver.givenName,
+          familyName: result.Driver.familyName,
+          code: result.Driver.code,
+        },
+        Constructor: { name: result.Constructor.name },
+        grid: result.grid,
+        laps: result.laps,
+        status: result.status,
+        Time: result.Time ? { time: result.Time.time } : null,
+        FastestLap: result.FastestLap
+          ? {
+              rank: result.FastestLap.rank,
+              lap: result.FastestLap.lap,
+              Time: result.FastestLap.Time
+                ? { time: result.FastestLap.Time.time }
+                : null,
+              AverageSpeed: result.FastestLap.AverageSpeed
+                ? {
+                    speed: result.FastestLap.AverageSpeed.speed,
+                    units: result.FastestLap.AverageSpeed.units,
+                  }
+                : null,
+            }
+          : null,
+        points: result.points,
+      })),
+      _timestamp: timestamp,
+    };
+  } catch {
+    return withYearFallback(getLastRaceResults, season);
   }
 };

--- a/src/components/DriverStandings.jsx
+++ b/src/components/DriverStandings.jsx
@@ -1,111 +1,50 @@
-import React, { useState, useEffect } from "react";
+import React, { useState } from "react";
 import { getDriverStandings } from "../api/f1Service";
+import { useFetchData } from "../hooks/useFetchData";
+import { getTeamHexColor, getTeamTextClass } from "../utils/teamColors";
 
-// Team color mapping
-const teamColors = {
-  "Red Bull": "bg-[#0600EF] border-[#0600EF]",
-  Ferrari: "bg-[#DC0000] border-[#DC0000]",
-  Mercedes: "bg-[#00D2BE] border-[#00D2BE]",
-  McLaren: "bg-[#FF8700] border-[#FF8700]",
-  "Aston Martin": "bg-[#006F62] border-[#006F62]",
-  Alpine: "bg-[#0090FF] border-[#0090FF]",
-  Williams: "bg-[#005AFF] border-[#005AFF]",
-  AlphaTauri: "bg-[#2B4562] border-[#2B4562]",
-  "Alfa Romeo": "bg-[#900000] border-[#900000]",
-  Haas: "bg-[#FFFFFF] border-[#FFFFFF] text-black",
-  RB: "bg-[#0600EF] border-[#0600EF]",
-  "Racing Bulls": "bg-[#0600EF] border-[#0600EF]",
-  "Visa Cash App RB": "bg-[#0600EF] border-[#0600EF]",
-  VCARB: "bg-[#0600EF] border-[#0600EF]",
-  Sauber: "bg-[#900000] border-[#900000]",
-  "Stake F1 Team": "bg-[#900000] border-[#900000]",
-  "Stake F1": "bg-[#900000] border-[#900000]",
+const positionClass = (index) => {
+  if (index === 0) return "border-yellow-500 text-yellow-500";
+  if (index === 1) return "border-gray-400 text-gray-400";
+  if (index === 2) return "border-amber-700 text-amber-700";
+  return "border-red-500/30 text-gray-400";
 };
 
-// Text color mapping
-const teamTextColors = {
-  "Red Bull": "text-[#0600EF]",
-  Ferrari: "text-[#DC0000]",
-  Mercedes: "text-[#00D2BE]",
-  McLaren: "text-[#FF8700]",
-  "Aston Martin": "text-[#006F62]",
-  Alpine: "text-[#0090FF]",
-  Williams: "text-[#005AFF]",
-  AlphaTauri: "text-[#2B4562]",
-  "Alfa Romeo": "text-[#900000]",
-  Haas: "text-[#FFFFFF]",
-  RB: "text-[#0600EF]",
-  "Racing Bulls": "text-[#0600EF]",
-  "Visa Cash App RB": "text-[#0600EF]",
-  VCARB: "text-[#0600EF]",
-  Sauber: "text-[#900000]",
-  "Stake F1 Team": "text-[#900000]",
-  "Stake F1": "text-[#900000]",
-};
-
-const getTeamColor = (teamName) => {
-  return teamColors[teamName] || "bg-gray-700 border-gray-700";
-};
-
-const getTeamTextColor = (teamName) => {
-  return teamTextColors[teamName] || "text-gray-400";
-};
+const SectionHeader = ({ lastUpdated, onRefresh, refreshing }) => (
+  <div className="mb-6 flex items-center justify-between">
+    <div className="flex items-center">
+      <div className="w-1 h-6 bg-red-500 mr-3"></div>
+      <div>
+        <h2 className="text-2xl font-bold">DRIVER STANDINGS</h2>
+        <div className="tech-text text-xs text-red-500 tracking-wider">
+          {lastUpdated && `UPDATED ${lastUpdated.toLocaleTimeString()} • `}
+          CURRENT SEASON
+        </div>
+      </div>
+    </div>
+    <button
+      onClick={onRefresh}
+      disabled={refreshing}
+      className={`tech-text text-xs px-4 py-2 border border-red-500/30 hover:border-red-500 hover:bg-red-500/10 transition-all duration-200 tech-corner flex items-center ${
+        refreshing ? "opacity-50 cursor-not-allowed" : ""
+      }`}
+    >
+      {refreshing ? (
+        <>
+          <div className="w-3 h-3 border-t-transparent border border-red-500 rounded-full animate-spin mr-2"></div>
+          UPDATING
+        </>
+      ) : (
+        "REFRESH DATA"
+      )}
+    </button>
+  </div>
+);
 
 const DriverStandings = () => {
-  const [standings, setStandings] = useState([]);
-  const [loading, setLoading] = useState(true);
-  const [error, setError] = useState(null);
-  const [lastUpdated, setLastUpdated] = useState(null);
-  const [refreshing, setRefreshing] = useState(false);
-  const [showAllDrivers, setShowAllDrivers] = useState(false);
-
-  const fetchStandings = async (showRefreshing = false) => {
-    try {
-      if (showRefreshing) {
-        setRefreshing(true);
-      } else {
-        setLoading(true);
-      }
-
-      // Add cache-busting parameter to force fresh data
-      const data = await getDriverStandings();
-      console.log("Driver standings data received:", data);
-
-      if (data === "No Data Fetched") {
-        setError("No Data Fetched");
-        setStandings([]);
-      } else if (data && Array.isArray(data)) {
-        console.log("Setting driver standings:", data);
-        setStandings(data);
-        setLastUpdated(new Date());
-        setError(null);
-      } else {
-        console.error("Invalid data format received:", data);
-        setError("Invalid data format received");
-        setStandings([]);
-      }
-
-      if (showRefreshing) {
-        setRefreshing(false);
-      } else {
-        setLoading(false);
-      }
-    } catch (err) {
-      console.error("Error in driver standings:", err);
-      setError("Failed to load driver standings");
-      setStandings([]);
-      setLoading(false);
-      setRefreshing(false);
-    }
-  };
-
-  useEffect(() => {
-    fetchStandings();
-  }, []);
-
-  const handleRefresh = () => {
-    fetchStandings(true);
-  };
+  const { data: standings, loading, error, refreshing, lastUpdated, refresh } =
+    useFetchData(getDriverStandings, Array.isArray);
+  const [showAll, setShowAll] = useState(false);
 
   if (loading)
     return (
@@ -120,27 +59,10 @@ const DriverStandings = () => {
       </div>
     );
 
-  // Only show the error state if there's an error AND no standings data
-  if (error && standings.length === 0)
+  if (error && !standings)
     return (
       <section id="standings" className="mb-16 pt-8">
-        <div className="mb-6 flex items-center justify-between">
-          <div className="flex items-center">
-            <div className="w-1 h-6 bg-red-500 mr-3"></div>
-            <div>
-              <h2 className="text-2xl font-bold">DRIVER STANDINGS</h2>
-              <div className="tech-text text-xs text-red-500 tracking-wider">
-                CURRENT SEASON
-              </div>
-            </div>
-          </div>
-          <button
-            onClick={handleRefresh}
-            className="tech-text text-xs px-4 py-2 border border-red-500/30 hover:border-red-500 hover:bg-red-500/10 transition-all duration-200 tech-corner"
-          >
-            REFRESH DATA
-          </button>
-        </div>
+        <SectionHeader onRefresh={refresh} refreshing={refreshing} />
         <div className="tech-card p-6 flex items-center justify-center tech-corner">
           <div className="text-center">
             <div className="w-12 h-12 mx-auto mb-4 border border-red-500/30 rounded-sm flex items-center justify-center">
@@ -170,68 +92,39 @@ const DriverStandings = () => {
       </section>
     );
 
-  if (standings.length === 0) return null;
+  if (!standings?.length) return null;
 
-  // Display only top 5 drivers or all drivers based on state
-  const displayedStandings = showAllDrivers ? standings : standings.slice(0, 5);
+  const displayed = showAll ? standings : standings.slice(0, 5);
 
   return (
     <section id="standings" className="mb-16 pt-8">
-      <div className="mb-6 flex items-center justify-between">
-        <div className="flex items-center">
-          <div className="w-1 h-6 bg-red-500 mr-3"></div>
-          <div>
-            <h2 className="text-2xl font-bold">DRIVER STANDINGS</h2>
-            <div className="tech-text text-xs text-red-500 tracking-wider">
-              {lastUpdated && `UPDATED ${lastUpdated.toLocaleTimeString()} • `}
-              CURRENT SEASON
-            </div>
-          </div>
-        </div>
-        <button
-          onClick={handleRefresh}
-          disabled={refreshing}
-          className={`tech-text text-xs px-4 py-2 border border-red-500/30 hover:border-red-500 hover:bg-red-500/10 transition-all duration-200 tech-corner flex items-center ${
-            refreshing ? "opacity-50 cursor-not-allowed" : ""
-          }`}
-        >
-          {refreshing ? (
-            <>
-              <div className="w-3 h-3 border-t-transparent border border-red-500 rounded-full animate-spin mr-2"></div>
-              UPDATING
-            </>
-          ) : (
-            "REFRESH DATA"
-          )}
-        </button>
-      </div>
+      <SectionHeader
+        lastUpdated={lastUpdated}
+        onRefresh={refresh}
+        refreshing={refreshing}
+      />
 
       <div className="tech-card tech-corner overflow-hidden">
         <div className="overflow-x-auto custom-scrollbar max-h-[500px]">
           <table className="w-full">
             <thead className="sticky top-0 bg-[#0A0F1B] z-10">
               <tr className="border-b border-red-500/20">
-                <th className="py-4 px-6 text-left tech-text text-xs text-red-500 tracking-wider">
-                  POS
-                </th>
-                <th className="py-4 px-6 text-left tech-text text-xs text-red-500 tracking-wider">
-                  DRIVER
-                </th>
-                <th className="py-4 px-6 text-left tech-text text-xs text-red-500 tracking-wider">
-                  TEAM
-                </th>
-                <th className="py-4 px-6 text-right tech-text text-xs text-red-500 tracking-wider">
-                  WINS
-                </th>
-                <th className="py-4 px-6 text-right tech-text text-xs text-red-500 tracking-wider">
-                  POINTS
-                </th>
+                {["POS", "DRIVER", "TEAM", "WINS", "POINTS"].map((col, i) => (
+                  <th
+                    key={col}
+                    className={`py-4 px-6 tech-text text-xs text-red-500 tracking-wider ${
+                      i >= 3 ? "text-right" : "text-left"
+                    }`}
+                  >
+                    {col}
+                  </th>
+                ))}
               </tr>
             </thead>
             <tbody className="divide-y divide-[#1E232F]/30">
-              {displayedStandings.map((driver, index) => (
+              {displayed.map((driver, index) => (
                 <tr
-                  key={index}
+                  key={driver.Driver?.driverId ?? index}
                   className={`${
                     index < 3
                       ? "bg-red-500/5"
@@ -242,15 +135,7 @@ const DriverStandings = () => {
                 >
                   <td className="py-4 px-6 whitespace-nowrap">
                     <div
-                      className={`w-8 h-8 flex items-center justify-center border ${
-                        index === 0
-                          ? "border-yellow-500 text-yellow-500"
-                          : index === 1
-                          ? "border-gray-400 text-gray-400"
-                          : index === 2
-                          ? "border-amber-700 text-amber-700"
-                          : "border-red-500/30 text-gray-400"
-                      }`}
+                      className={`w-8 h-8 flex items-center justify-center border ${positionClass(index)}`}
                     >
                       <span className="tech-text text-sm">
                         {driver.position}
@@ -262,11 +147,11 @@ const DriverStandings = () => {
                       <div
                         className="w-1 h-10 mr-4"
                         style={{
-                          backgroundColor: getTeamColor(
+                          backgroundColor: getTeamHexColor(
                             driver.Constructor?.name
                           ),
                         }}
-                      ></div>
+                      />
                       <div>
                         <div className="font-medium">
                           {driver.Driver?.givenName} {driver.Driver?.familyName}
@@ -279,7 +164,7 @@ const DriverStandings = () => {
                   </td>
                   <td className="py-4 px-6 whitespace-nowrap">
                     <span
-                      className={`px-3 py-1 text-xs tech-text font-bold ${getTeamTextColor(
+                      className={`px-3 py-1 text-xs tech-text font-bold ${getTeamTextClass(
                         driver.Constructor?.name
                       )}`}
                     >
@@ -305,12 +190,10 @@ const DriverStandings = () => {
 
       <div className="flex justify-center mt-6">
         <button
-          onClick={() => setShowAllDrivers(!showAllDrivers)}
+          onClick={() => setShowAll(!showAll)}
           className="tech-text text-xs px-6 py-3 border border-red-500/30 hover:border-red-500 hover:bg-red-500/10 transition-all duration-200 tech-corner"
         >
-          {showAllDrivers
-            ? "SHOW TOP 5"
-            : `SHOW ALL DRIVERS (${standings.length})`}
+          {showAll ? "SHOW TOP 5" : `SHOW ALL DRIVERS (${standings.length})`}
         </button>
       </div>
     </section>

--- a/src/components/LastRaceResults.jsx
+++ b/src/components/LastRaceResults.jsx
@@ -1,176 +1,88 @@
-import React, { useState, useEffect } from "react";
+import React, { useState } from "react";
 import { getLastRaceResults } from "../api/f1Service";
+import { useFetchData } from "../hooks/useFetchData";
+import { getTeamHexColor, getTeamTextClass } from "../utils/teamColors";
 
-// Team color mapping
-const teamColors = {
-  "Red Bull": "bg-blue-800",
-  Ferrari: "bg-red-600",
-  Mercedes: "bg-teal-500",
-  McLaren: "bg-orange-500",
-  "Aston Martin": "bg-green-600",
-  Alpine: "bg-blue-500",
-  Williams: "bg-blue-700",
-  AlphaTauri: "bg-navy-500",
-  "Alfa Romeo": "bg-red-800",
-  "Haas F1 Team": "bg-gray-500",
-  "Racing Point": "bg-pink-500",
-  Renault: "bg-yellow-500",
-  "Toro Rosso": "bg-blue-600",
-  Sauber: "bg-red-700",
-  "Force India": "bg-pink-600",
-  "Lotus F1": "bg-black",
-  Marussia: "bg-red-500",
-  Caterham: "bg-green-500",
-  HRT: "bg-gray-600",
-  Virgin: "bg-red-400",
-  "Brawn GP": "bg-green-400",
-  Toyota: "bg-red-300",
-  "Super Aguri": "bg-white",
-  Spyker: "bg-orange-600",
-  Midland: "bg-red-200",
-  Minardi: "bg-black",
-  Jaguar: "bg-green-700",
-  BAR: "bg-white",
-  Jordan: "bg-yellow-600",
-  Arrows: "bg-orange-700",
-  Prost: "bg-blue-400",
-  Benetton: "bg-green-300",
-  Stewart: "bg-white",
-  Tyrrell: "bg-blue-300",
-  Lola: "bg-red-100",
-  Forti: "bg-yellow-700",
-  Simtek: "bg-purple-500",
-  Pacific: "bg-teal-400",
-  Larrousse: "bg-yellow-400",
-  Footwork: "bg-white",
-  Brabham: "bg-teal-300",
-  "Andrea Moda": "bg-black",
-  March: "bg-green-200",
-  Fondmetal: "bg-teal-200",
-  Coloni: "bg-yellow-300",
+const validateResults = (data) =>
+  data?.results && Array.isArray(data.results);
+
+const positionClass = (index) => {
+  if (index === 0) return "border-yellow-500 text-yellow-500";
+  if (index === 1) return "border-gray-400 text-gray-400";
+  if (index === 2) return "border-amber-700 text-amber-700";
+  return "border-red-500/30 text-gray-400";
 };
 
-// Text color mapping
-const teamTextColors = {
-  "Red Bull": "text-blue-800",
-  Ferrari: "text-red-600",
-  Mercedes: "text-teal-500",
-  McLaren: "text-orange-500",
-  "Aston Martin": "text-green-600",
-  Alpine: "text-blue-500",
-  Williams: "text-blue-700",
-  AlphaTauri: "text-navy-500",
-  "Alfa Romeo": "text-red-800",
-  "Haas F1 Team": "text-gray-500",
-  "Racing Point": "text-pink-500",
-  Renault: "text-yellow-500",
-  "Toro Rosso": "text-blue-600",
-  Sauber: "text-red-700",
-  "Force India": "text-pink-600",
-  "Lotus F1": "text-black",
-  Marussia: "text-red-500",
-  Caterham: "text-green-500",
-  HRT: "text-gray-600",
-  Virgin: "text-red-400",
-  "Brawn GP": "text-green-400",
-  Toyota: "text-red-300",
-  "Super Aguri": "text-white",
-  Spyker: "text-orange-600",
-  Midland: "text-red-200",
-  Minardi: "text-black",
-  Jaguar: "text-green-700",
-  BAR: "text-white",
-  Jordan: "text-yellow-600",
-  Arrows: "text-orange-700",
-  Prost: "text-blue-400",
-  Benetton: "text-green-300",
-  Stewart: "text-white",
-  Tyrrell: "text-blue-300",
-  Lola: "text-red-100",
-  Forti: "text-yellow-700",
-  Simtek: "text-purple-500",
-  Pacific: "text-teal-400",
-  Larrousse: "text-yellow-400",
-  Footwork: "text-white",
-  Brabham: "text-teal-300",
-  "Andrea Moda": "text-black",
-  March: "text-green-200",
-  Fondmetal: "text-teal-200",
-  Coloni: "text-yellow-300",
-};
+const RefreshButton = ({ onRefresh, refreshing }) => (
+  <button
+    onClick={onRefresh}
+    disabled={refreshing}
+    className={`tech-text text-xs px-4 py-2 border border-red-500/30 hover:border-red-500 hover:bg-red-500/10 transition-all duration-200 tech-corner flex items-center ${
+      refreshing ? "opacity-50 cursor-not-allowed" : ""
+    }`}
+  >
+    {refreshing ? (
+      <>
+        <div className="w-3 h-3 border-t-transparent border border-red-500 rounded-full animate-spin mr-2"></div>
+        UPDATING
+      </>
+    ) : (
+      "REFRESH DATA"
+    )}
+  </button>
+);
 
-const getTeamColor = (teamName) => {
-  return teamColors[teamName] || "bg-gray-500";
-};
-
-const getTeamTextColor = (teamName) => {
-  return teamTextColors[teamName] || "text-gray-500";
-};
+const SectionHeader = ({ results, error, lastUpdated, onRefresh, refreshing, showAll, onToggleAll }) => (
+  <div className="flex justify-between items-center mb-6">
+    <div className="flex items-center">
+      <div className="w-1 h-6 bg-red-500 mr-3"></div>
+      <div>
+        <h2 className="text-2xl font-bold">LAST RACE RESULTS</h2>
+        <div className="tech-text text-xs text-red-500 tracking-wider">
+          {results ? (
+            <>
+              {error ? `${error} • ` : ""}
+              {results.raceName.toUpperCase()} •{" "}
+              {new Date(results.date)
+                .toLocaleDateString("en-GB", {
+                  day: "2-digit",
+                  month: "short",
+                  year: "numeric",
+                })
+                .toUpperCase()}
+              {lastUpdated && ` • UPDATED ${lastUpdated.toLocaleTimeString()}`}
+            </>
+          ) : (
+            "MOST RECENT GRAND PRIX"
+          )}
+        </div>
+      </div>
+    </div>
+    <div className="flex items-center space-x-2">
+      <RefreshButton onRefresh={onRefresh} refreshing={refreshing} />
+      {results && (
+        <button
+          onClick={onToggleAll}
+          className="tech-text text-xs px-4 py-2 border border-red-500/30 hover:border-red-500 hover:bg-red-500/10 transition-all duration-200 tech-corner"
+        >
+          {showAll ? "HIDE ALL POSITIONS" : "SHOW ALL POSITIONS"}
+        </button>
+      )}
+    </div>
+  </div>
+);
 
 const LastRaceResults = () => {
-  const [results, setResults] = useState(null);
-  const [loading, setLoading] = useState(true);
-  const [error, setError] = useState(null);
-  const [viewAll, setViewAll] = useState(false);
-  const [showAllPositions, setShowAllPositions] = useState(false);
-  const [showAllDriversInPositions, setShowAllDriversInPositions] =
-    useState(false);
-  const [lastUpdated, setLastUpdated] = useState(null);
-  const [refreshing, setRefreshing] = useState(false);
+  const { data: results, loading, error, refreshing, lastUpdated, refresh } =
+    useFetchData(getLastRaceResults, validateResults);
+  const [showAll, setShowAll] = useState(false);
+  const [showAllDrivers, setShowAllDrivers] = useState(false);
 
-  const fetchResults = async (showRefreshing = false) => {
-    try {
-      if (showRefreshing) {
-        setRefreshing(true);
-      } else {
-        setLoading(true);
-      }
-
-      // Add timestamp to force fresh data
-      const data = await getLastRaceResults();
-      console.log("Last race results data received:", data);
-
-      if (data === "No Data Fetched") {
-        setError("No Data Fetched");
-        setResults(null);
-      } else if (data && data.results && Array.isArray(data.results)) {
-        console.log("Setting last race results:", data);
-        setResults(data);
-        // Check if data is from previous season
-        if (data.season < new Date().getFullYear()) {
-          setError(`Showing data from ${data.season} season`);
-        } else {
-          // Set a message for current season data but don't treat it as an error
-          setError(null);
-        }
-        setLastUpdated(new Date());
-      } else {
-        console.error("Invalid data format received:", data);
-        setError("Invalid data format received");
-        setResults(null);
-      }
-
-      if (showRefreshing) {
-        setRefreshing(false);
-      } else {
-        setLoading(false);
-      }
-    } catch (err) {
-      console.error("Error in last race results:", err);
-      setError("Failed to load last race results");
-      setResults(null);
-      setLoading(false);
-      setRefreshing(false);
-    }
-  };
-
-  useEffect(() => {
-    fetchResults();
-  }, []);
-
-  const handleRefresh = () => {
-    fetchResults(true);
-  };
+  const prevSeasonError =
+    results && results.season < new Date().getFullYear()
+      ? `Showing data from ${results.season} season`
+      : null;
+  const displayError = prevSeasonError || (error && !results ? error : null);
 
   if (loading)
     return (
@@ -185,27 +97,14 @@ const LastRaceResults = () => {
       </div>
     );
 
-  // Only show the error state if there's an error AND no results data
   if (error && !results)
     return (
       <section id="results" className="mb-16">
-        <div className="mb-6 flex items-center justify-between">
-          <div className="flex items-center">
-            <div className="w-1 h-6 bg-red-500 mr-3"></div>
-            <div>
-              <h2 className="text-2xl font-bold">LAST RACE RESULTS</h2>
-              <div className="tech-text text-xs text-red-500 tracking-wider">
-                MOST RECENT GRAND PRIX
-              </div>
-            </div>
-          </div>
-          <button
-            onClick={handleRefresh}
-            className="tech-text text-xs px-4 py-2 border border-red-500/30 hover:border-red-500 hover:bg-red-500/10 transition-all duration-200 tech-corner"
-          >
-            REFRESH DATA
-          </button>
-        </div>
+        <SectionHeader
+          error={displayError}
+          onRefresh={refresh}
+          refreshing={refreshing}
+        />
         <div className="tech-card p-6 flex items-center justify-center tech-corner">
           <div className="text-center">
             <div className="w-12 h-12 mx-auto mb-4 border border-red-500/30 rounded-sm flex items-center justify-center">
@@ -237,58 +136,25 @@ const LastRaceResults = () => {
 
   if (!results) return null;
 
-  const displayedResults = viewAll
+  const winner = results.results[0];
+  const tableRows = showAllDrivers
     ? results.results
-    : results.results.slice(0, 10);
+    : results.results.slice(0, 5);
 
   return (
     <section id="results" className="mb-16">
-      <div className="flex justify-between items-center mb-6">
-        <div className="flex items-center">
-          <div className="w-1 h-6 bg-red-500 mr-3"></div>
-          <div>
-            <h2 className="text-2xl font-bold">LAST RACE RESULTS</h2>
-            <div className="tech-text text-xs text-red-500 tracking-wider">
-              {error ? error + " • " : ""}
-              {results.raceName.toUpperCase()} •{" "}
-              {new Date(results.date)
-                .toLocaleDateString("en-GB", {
-                  day: "2-digit",
-                  month: "short",
-                  year: "numeric",
-                })
-                .toUpperCase()}
-              {lastUpdated && ` • UPDATED ${lastUpdated.toLocaleTimeString()}`}
-            </div>
-          </div>
-        </div>
-        <div className="flex items-center space-x-2">
-          <button
-            onClick={handleRefresh}
-            disabled={refreshing}
-            className={`tech-text text-xs px-4 py-2 border border-red-500/30 hover:border-red-500 hover:bg-red-500/10 transition-all duration-200 tech-corner flex items-center ${
-              refreshing ? "opacity-50 cursor-not-allowed" : ""
-            }`}
-          >
-            {refreshing ? (
-              <>
-                <div className="w-3 h-3 border-t-transparent border border-red-500 rounded-full animate-spin mr-2"></div>
-                UPDATING
-              </>
-            ) : (
-              "REFRESH DATA"
-            )}
-          </button>
-          <button
-            onClick={() => setViewAll(!viewAll)}
-            className="tech-text text-xs px-4 py-2 border border-red-500/30 hover:border-red-500 hover:bg-red-500/10 transition-all duration-200 tech-corner"
-          >
-            {viewAll ? "SHOW TOP 10" : "VIEW ALL"}
-          </button>
-        </div>
-      </div>
+      <SectionHeader
+        results={results}
+        error={displayError}
+        lastUpdated={lastUpdated}
+        onRefresh={refresh}
+        refreshing={refreshing}
+        showAll={showAll}
+        onToggleAll={() => setShowAll(!showAll)}
+      />
 
       <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
+        {/* Winner card */}
         <div className="tech-card tech-corner tech-scan p-6">
           <div className="tech-text text-xs text-red-500 tracking-wider mb-4">
             RACE WINNER
@@ -299,71 +165,70 @@ const LastRaceResults = () => {
             </div>
             <div className="flex-grow">
               <div className="text-2xl font-bold">
-                {results.results[0].Driver.givenName}{" "}
-                {results.results[0].Driver.familyName}
+                {winner.Driver.givenName} {winner.Driver.familyName}
               </div>
-              <div className="flex items-center">
-                <span
-                  className={`text-sm tech-text font-bold ${getTeamTextColor(
-                    results.results[0].Constructor.name
-                  )}`}
-                >
-                  {results.results[0].Constructor.name}
-                </span>
-              </div>
+              <span
+                className={`text-sm tech-text font-bold ${getTeamTextClass(
+                  winner.Constructor.name
+                )}`}
+              >
+                {winner.Constructor.name}
+              </span>
             </div>
             <div className="text-right">
               <div className="font-medium text-lg">
-                {results.results[0].Time?.time || results.results[0].status}
+                {winner.Time?.time || winner.status}
               </div>
               <div className="tech-text text-red-500 text-sm">
-                {results.results[0].points} PTS
+                {winner.points} PTS
               </div>
             </div>
           </div>
 
           <div className="grid grid-cols-3 gap-4 mb-6">
-            <div className="bg-black/30 border border-red-500/20 p-4 text-center">
-              <div className="tech-text text-xs text-red-500 mb-1">GRID</div>
-              <div className="text-2xl font-bold">
-                {results.results[0].grid}
+            {[
+              { label: "GRID", value: winner.grid },
+              { label: "LAPS", value: winner.laps },
+              { label: "POINTS", value: winner.points, glow: true },
+            ].map(({ label, value, glow }) => (
+              <div
+                key={label}
+                className="bg-black/30 border border-red-500/20 p-4 text-center"
+              >
+                <div className="tech-text text-xs text-red-500 mb-1">
+                  {label}
+                </div>
+                <div className={`text-2xl font-bold${glow ? " tech-glow" : ""}`}>
+                  {value}
+                </div>
               </div>
-            </div>
-            <div className="bg-black/30 border border-red-500/20 p-4 text-center">
-              <div className="tech-text text-xs text-red-500 mb-1">LAPS</div>
-              <div className="text-2xl font-bold">
-                {results.results[0].laps}
-              </div>
-            </div>
-            <div className="bg-black/30 border border-red-500/20 p-4 text-center">
-              <div className="tech-text text-xs text-red-500 mb-1">POINTS</div>
-              <div className="text-2xl font-bold tech-glow">
-                {results.results[0].points}
-              </div>
-            </div>
+            ))}
           </div>
 
-          {results.results[0].FastestLap && (
+          {winner.FastestLap && (
             <div className="bg-black/30 border border-red-500/20 p-4">
               <div className="tech-text text-xs text-red-500 mb-3 text-center">
                 FASTEST LAP
               </div>
               <div className="flex justify-between items-center">
                 <div className="text-3xl font-bold tech-glow">
-                  {results.results[0].FastestLap.Time.time}
+                  {winner.FastestLap.Time?.time ?? "—"}
                 </div>
                 <div className="tech-text text-sm text-gray-400">
-                  LAP {results.results[0].FastestLap.lap}
+                  LAP {winner.FastestLap.lap}
                 </div>
               </div>
-              <div className="tech-text text-xs text-gray-400 mt-1">
-                {results.results[0].FastestLap.AverageSpeed.speed}{" "}
-                {results.results[0].FastestLap.AverageSpeed.units}
-              </div>
+              {winner.FastestLap.AverageSpeed && (
+                <div className="tech-text text-xs text-gray-400 mt-1">
+                  {winner.FastestLap.AverageSpeed.speed}{" "}
+                  {winner.FastestLap.AverageSpeed.units}
+                </div>
+              )}
             </div>
           )}
         </div>
 
+        {/* Podium card */}
         <div className="tech-card tech-corner">
           <div className="p-4">
             <div className="tech-text text-xs text-red-500 tracking-wider mb-3 border-b border-red-500/20 pb-2">
@@ -376,13 +241,7 @@ const LastRaceResults = () => {
                   className="p-3 hover:bg-[#1A1F2A]/30 transition-colors duration-150 flex items-center"
                 >
                   <div
-                    className={`w-10 h-10 flex items-center justify-center border mr-3 ${
-                      index === 0
-                        ? "border-yellow-500 text-yellow-500"
-                        : index === 1
-                        ? "border-gray-400 text-gray-400"
-                        : "border-amber-700 text-amber-700"
-                    }`}
+                    className={`w-10 h-10 flex items-center justify-center border mr-3 ${positionClass(index)}`}
                   >
                     <span className="tech-text text-lg">{result.position}</span>
                   </div>
@@ -390,15 +249,13 @@ const LastRaceResults = () => {
                     <div className="font-bold">
                       {result.Driver.givenName} {result.Driver.familyName}
                     </div>
-                    <div className="flex items-center">
-                      <span
-                        className={`text-sm tech-text font-bold ${getTeamTextColor(
-                          result.Constructor.name
-                        )}`}
-                      >
-                        {result.Constructor.name}
-                      </span>
-                    </div>
+                    <span
+                      className={`text-sm tech-text font-bold ${getTeamTextClass(
+                        result.Constructor.name
+                      )}`}
+                    >
+                      {result.Constructor.name}
+                    </span>
                   </div>
                   <div className="text-right">
                     <div className="font-medium">
@@ -415,49 +272,28 @@ const LastRaceResults = () => {
         </div>
       </div>
 
-      <div className="flex justify-center mt-6 mb-6">
-        <button
-          onClick={() => setShowAllPositions(!showAllPositions)}
-          className="tech-text text-xs px-6 py-3 border border-red-500/30 hover:border-red-500 hover:bg-red-500/10 transition-all duration-200 tech-corner"
-        >
-          {showAllPositions ? "HIDE ALL POSITIONS" : "SHOW ALL POSITIONS"}
-        </button>
-      </div>
-
-      {showAllPositions && (
-        <div className="tech-card p-6 tech-corner">
+      {showAll && (
+        <div className="tech-card p-6 tech-corner mt-6">
           <div className="overflow-x-auto custom-scrollbar max-h-[500px]">
             <table className="w-full">
               <thead className="sticky top-0 bg-[#0A0F1B] z-10">
                 <tr className="border-b border-red-500/20">
-                  <th className="py-4 px-6 text-left tech-text text-xs text-red-500 tracking-wider">
-                    POS
-                  </th>
-                  <th className="py-4 px-6 text-left tech-text text-xs text-red-500 tracking-wider">
-                    DRIVER
-                  </th>
-                  <th className="py-4 px-6 text-left tech-text text-xs text-red-500 tracking-wider">
-                    TEAM
-                  </th>
-                  <th className="py-4 px-6 text-left tech-text text-xs text-red-500 tracking-wider">
-                    GRID
-                  </th>
-                  <th className="py-4 px-6 text-left tech-text text-xs text-red-500 tracking-wider">
-                    LAPS
-                  </th>
-                  <th className="py-4 px-6 text-left tech-text text-xs text-red-500 tracking-wider">
-                    TIME/STATUS
-                  </th>
-                  <th className="py-4 px-6 text-right tech-text text-xs text-red-500 tracking-wider">
-                    PTS
-                  </th>
+                  {["POS", "DRIVER", "TEAM", "GRID", "LAPS", "TIME/STATUS", "PTS"].map(
+                    (col, i) => (
+                      <th
+                        key={col}
+                        className={`py-4 px-6 tech-text text-xs text-red-500 tracking-wider ${
+                          i === 6 ? "text-right" : "text-left"
+                        }`}
+                      >
+                        {col}
+                      </th>
+                    )
+                  )}
                 </tr>
               </thead>
               <tbody className="divide-y divide-[#1E232F]/30">
-                {(showAllDriversInPositions
-                  ? results.results
-                  : results.results.slice(0, 5)
-                ).map((result, index) => (
+                {tableRows.map((result, index) => (
                   <tr
                     key={index}
                     className={`${
@@ -470,15 +306,7 @@ const LastRaceResults = () => {
                   >
                     <td className="py-4 px-6 whitespace-nowrap">
                       <div
-                        className={`w-8 h-8 flex items-center justify-center border ${
-                          index === 0
-                            ? "border-yellow-500 text-yellow-500"
-                            : index === 1
-                            ? "border-gray-400 text-gray-400"
-                            : index === 2
-                            ? "border-amber-700 text-amber-700"
-                            : "border-red-500/30 text-gray-400"
-                        }`}
+                        className={`w-8 h-8 flex items-center justify-center border ${positionClass(index)}`}
                       >
                         <span className="tech-text text-sm">
                           {result.position}
@@ -488,10 +316,13 @@ const LastRaceResults = () => {
                     <td className="py-4 px-6 whitespace-nowrap">
                       <div className="flex items-center">
                         <div
-                          className={`w-1 h-10 ${getTeamColor(
-                            result.Constructor.name
-                          )} mr-3`}
-                        ></div>
+                          className="w-1 h-10 mr-3"
+                          style={{
+                            backgroundColor: getTeamHexColor(
+                              result.Constructor.name
+                            ),
+                          }}
+                        />
                         <div>
                           <div className="font-bold">
                             {result.Driver.familyName.toUpperCase()}
@@ -504,19 +335,15 @@ const LastRaceResults = () => {
                     </td>
                     <td className="py-4 px-6 whitespace-nowrap">
                       <span
-                        className={`px-3 py-1 text-xs tech-text ${getTeamTextColor(
+                        className={`px-3 py-1 text-xs tech-text font-medium ${getTeamTextClass(
                           result.Constructor.name
-                        )} font-medium`}
+                        )}`}
                       >
                         {result.Constructor.name}
                       </span>
                     </td>
-                    <td className="py-4 px-6 whitespace-nowrap">
-                      {result.grid}
-                    </td>
-                    <td className="py-4 px-6 whitespace-nowrap">
-                      {result.laps}
-                    </td>
+                    <td className="py-4 px-6 whitespace-nowrap">{result.grid}</td>
+                    <td className="py-4 px-6 whitespace-nowrap">{result.laps}</td>
                     <td className="py-4 px-6 whitespace-nowrap">
                       {result.Time ? result.Time.time : result.status}
                     </td>
@@ -531,27 +358,16 @@ const LastRaceResults = () => {
             </table>
           </div>
 
-          {!showAllDriversInPositions && results.results.length > 5 && (
-            <div className="flex justify-center mt-4">
-              <button
-                onClick={() => setShowAllDriversInPositions(true)}
-                className="tech-text text-xs px-4 py-2 border border-red-500/30 hover:border-red-500 hover:bg-red-500/10 transition-all duration-200 tech-corner"
-              >
-                SHOW ALL {results.results.length} DRIVERS
-              </button>
-            </div>
-          )}
-
-          {showAllDriversInPositions && (
-            <div className="flex justify-center mt-4">
-              <button
-                onClick={() => setShowAllDriversInPositions(false)}
-                className="tech-text text-xs px-4 py-2 border border-red-500/30 hover:border-red-500 hover:bg-red-500/10 transition-all duration-200 tech-corner"
-              >
-                SHOW TOP 5
-              </button>
-            </div>
-          )}
+          <div className="flex justify-center mt-4">
+            <button
+              onClick={() => setShowAllDrivers(!showAllDrivers)}
+              className="tech-text text-xs px-4 py-2 border border-red-500/30 hover:border-red-500 hover:bg-red-500/10 transition-all duration-200 tech-corner"
+            >
+              {showAllDrivers
+                ? "SHOW TOP 5"
+                : `SHOW ALL ${results.results.length} DRIVERS`}
+            </button>
+          </div>
         </div>
       )}
     </section>

--- a/src/components/RaceSchedule.jsx
+++ b/src/components/RaceSchedule.jsx
@@ -1,112 +1,74 @@
-import React, { useState, useEffect } from "react";
+import React, { useEffect } from "react";
 import { getRaceSchedule } from "../api/f1Service";
+import { useFetchData } from "../hooks/useFetchData";
+import {
+  formatDate,
+  formatTime,
+  isPastRace,
+  getDaysUntilRace,
+  getNextRace,
+  groupRacesByMonth,
+} from "../utils/raceUtils";
+
+const validateRaces = (races) =>
+  Array.isArray(races) &&
+  races.length > 0 &&
+  races.every(
+    (r) =>
+      r?.season &&
+      r?.round &&
+      r?.raceName &&
+      r?.date &&
+      r?.Circuit?.circuitName &&
+      r?.Circuit?.Location?.locality &&
+      r?.Circuit?.Location?.country
+  );
 
 const RaceSchedule = () => {
-  const [races, setRaces] = useState([]);
-  const [loading, setLoading] = useState(true);
-  const [error, setError] = useState(null);
-  const [seasonYear, setSeasonYear] = useState(new Date().getFullYear());
-  const [lastUpdated, setLastUpdated] = useState(null);
-  const [isRefreshing, setIsRefreshing] = useState(false);
+  const { data: races, loading, error, refreshing, lastUpdated, refresh } =
+    useFetchData(getRaceSchedule, validateRaces);
 
-  const fetchRaces = async (isManualRefresh = false) => {
-    try {
-      if (isManualRefresh) {
-        setIsRefreshing(true);
-      } else {
-        setLoading(true);
-      }
-
-      // Use the current year
-      const currentYear = new Date().getFullYear();
-      setSeasonYear(currentYear);
-
-      console.log("Fetching race schedule for year:", currentYear);
-      const data = await getRaceSchedule(currentYear);
-      console.log("Race schedule data received:", data);
-      console.log("Data type:", typeof data, Array.isArray(data));
-
-      if (data === "No Data Fetched") {
-        console.log("No data fetched from API");
-        setError("No Data Fetched");
-        setRaces([]);
-      } else if (data && Array.isArray(data) && data.length > 0) {
-        console.log(`Received ${data.length} races, first race:`, data[0]);
-
-        // Verify that the data has the expected structure
-        const hasValidStructure = data.every(
-          (race) =>
-            race &&
-            race.season &&
-            race.round &&
-            race.raceName &&
-            race.date &&
-            race.Circuit &&
-            race.Circuit.circuitName &&
-            race.Circuit.Location &&
-            race.Circuit.Location.locality &&
-            race.Circuit.Location.country
-        );
-
-        if (!hasValidStructure) {
-          console.error("Race data has invalid structure:", data[0]);
-          setError("Invalid data structure");
-          setRaces([]);
-          setLoading(false);
-          setIsRefreshing(false);
-          return;
-        }
-
-        // The OpenF1 API already returns dates in the correct format
-        // and our service handles year adjustments, so we can use the data directly
-        setRaces(data);
-
-        // Check if data is from previous season
-        if (data[0].season < currentYear) {
-          console.log(`Data is from previous season: ${data[0].season}`);
-          setError(`Showing data from ${data[0].season} season`);
-          setSeasonYear(data[0].season);
-        } else {
-          console.log("Data is from current season");
-          setError(null);
-        }
-
-        setLastUpdated(new Date());
-      } else {
-        console.warn("No race schedule data returned or empty array");
-        console.warn("Data received:", data);
-        setError("No data fetched");
-        setRaces([]);
-      }
-
-      if (isManualRefresh) {
-        setIsRefreshing(false);
-      } else {
-        setLoading(false);
-      }
-    } catch (err) {
-      console.error("Error in race schedule:", err);
-      setError("Failed to load race schedule");
-      setRaces([]);
-      setIsRefreshing(false);
-      setLoading(false);
-    }
-  };
-
-  const handleRefresh = () => {
-    fetchRaces(true);
-  };
-
+  // Auto-refresh every 5 minutes
   useEffect(() => {
-    fetchRaces();
-
-    // Set up auto-refresh every 5 minutes
-    const refreshInterval = setInterval(() => {
-      fetchRaces(true);
-    }, 5 * 60 * 1000);
-
-    return () => clearInterval(refreshInterval);
+    const interval = setInterval(() => refresh(), 5 * 60 * 1000);
+    return () => clearInterval(interval);
   }, []);
+
+  const currentYear = new Date().getFullYear();
+  const seasonYear = races?.[0]?.season ?? currentYear;
+  const prevSeasonNote =
+    seasonYear < currentYear ? `Showing ${seasonYear} season` : null;
+
+  const SectionHeader = () => (
+    <div className="mb-6 flex items-center justify-between">
+      <div className="flex items-center">
+        <div className="w-1 h-6 bg-red-500 mr-3"></div>
+        <div>
+          <h2 className="text-2xl font-bold">RACE CALENDAR</h2>
+          <div className="tech-text text-xs text-red-500 tracking-wider">
+            {prevSeasonNote ? `${prevSeasonNote.toUpperCase()} • ` : ""}
+            {seasonYear} SEASON
+          </div>
+        </div>
+      </div>
+      <div className="flex flex-col items-end">
+        <button
+          onClick={refresh}
+          disabled={refreshing}
+          className={`tech-button px-3 py-1 text-xs ${
+            refreshing ? "opacity-50 cursor-not-allowed" : ""
+          }`}
+        >
+          {refreshing ? "REFRESHING..." : "REFRESH"}
+        </button>
+        {lastUpdated && (
+          <div className="text-xs text-gray-500 mt-1">
+            Updated: {lastUpdated.toLocaleTimeString()}
+          </div>
+        )}
+      </div>
+    </div>
+  );
 
   if (loading)
     return (
@@ -121,29 +83,10 @@ const RaceSchedule = () => {
       </div>
     );
 
-  if (error || races.length === 0)
+  if (error || !races?.length)
     return (
       <section id="schedule" className="h-full sticky top-24">
-        <div className="mb-6 flex items-center justify-between">
-          <div className="flex items-center">
-            <div className="w-1 h-6 bg-red-500 mr-3"></div>
-            <div>
-              <h2 className="text-2xl font-bold">RACE CALENDAR</h2>
-              <div className="tech-text text-xs text-red-500 tracking-wider">
-                {seasonYear} SEASON
-              </div>
-            </div>
-          </div>
-          <button
-            onClick={handleRefresh}
-            disabled={isRefreshing}
-            className={`tech-button px-3 py-1 text-xs ${
-              isRefreshing ? "opacity-50 cursor-not-allowed" : ""
-            }`}
-          >
-            {isRefreshing ? "REFRESHING..." : "REFRESH"}
-          </button>
-        </div>
+        <SectionHeader />
         <div className="tech-card p-6 h-[calc(100%-100px)] flex items-center justify-center tech-corner">
           <div className="text-center">
             <div className="w-12 h-12 mx-auto mb-4 border border-red-500/30 rounded-sm flex items-center justify-center">
@@ -173,142 +116,12 @@ const RaceSchedule = () => {
       </section>
     );
 
-  // Function to format date
-  const formatDate = (dateString, timeString) => {
-    try {
-      if (!dateString) return "TBD";
-      // Handle different date formats
-      let date;
-      if (typeof dateString === "string" && dateString.includes("T")) {
-        // ISO format with time
-        date = new Date(dateString);
-      } else if (timeString) {
-        // Separate date and time
-        date = new Date(`${dateString}T${timeString || "00:00:00Z"}`);
-      } else {
-        // Just date
-        date = new Date(dateString);
-      }
-
-      return new Intl.DateTimeFormat("en-GB", {
-        day: "numeric",
-        month: "short",
-        year: "numeric",
-      }).format(date);
-    } catch (e) {
-      console.error("Error formatting date:", e, dateString, timeString);
-      return "Date TBD";
-    }
-  };
-
-  // Function to format time
-  const formatTime = (dateString, timeString) => {
-    try {
-      if (!dateString) return "";
-
-      // Handle different time formats
-      let date;
-      if (typeof dateString === "string" && dateString.includes("T")) {
-        // ISO format with time
-        date = new Date(dateString);
-      } else if (timeString) {
-        // Separate date and time
-        date = new Date(`${dateString}T${timeString}`);
-      } else {
-        // No time available
-        return "";
-      }
-
-      return new Intl.DateTimeFormat("en-GB", {
-        hour: "2-digit",
-        minute: "2-digit",
-      }).format(date);
-    } catch (e) {
-      console.error("Error formatting time:", e, dateString, timeString);
-      return "";
-    }
-  };
-
-  // Function to check if race is in the past
-  const isPastRace = (dateString) => {
-    if (!dateString) return false;
-    try {
-      const raceDate = new Date(dateString);
-      const today = new Date();
-      return raceDate < today;
-    } catch (e) {
-      return false;
-    }
-  };
-
-  // Function to get next race
-  const getNextRace = () => {
-    const today = new Date();
-    return races.find((race) => new Date(race.date) > today) || null;
-  };
-
-  const nextRace = getNextRace();
-
-  // Calculate days until next race
-  const getDaysUntilRace = (raceDate) => {
-    const today = new Date();
-    const race = new Date(raceDate);
-    const diffTime = Math.abs(race - today);
-    const diffDays = Math.ceil(diffTime / (1000 * 60 * 60 * 24));
-    return diffDays;
-  };
-
-  // Group races by month
-  const groupedRaces = races.reduce((acc, race) => {
-    try {
-      const date = new Date(race.date);
-      const month = date.toLocaleString("default", { month: "long" });
-
-      if (!acc[month]) {
-        acc[month] = [];
-      }
-
-      acc[month].push(race);
-    } catch (e) {
-      // If date parsing fails, add to "Unknown" group
-      if (!acc["Unknown"]) {
-        acc["Unknown"] = [];
-      }
-      acc["Unknown"].push(race);
-    }
-
-    return acc;
-  }, {});
+  const nextRace = getNextRace(races);
+  const groupedRaces = groupRacesByMonth(races);
 
   return (
     <section id="schedule" className="h-full sticky top-24">
-      <div className="mb-6 flex items-center justify-between">
-        <div className="flex items-center">
-          <div className="w-1 h-6 bg-red-500 mr-3"></div>
-          <div>
-            <h2 className="text-2xl font-bold">RACE CALENDAR</h2>
-            <div className="tech-text text-xs text-red-500 tracking-wider">
-              {seasonYear} SEASON
-            </div>
-          </div>
-        </div>
-        <div className="flex flex-col items-end">
-          <button
-            onClick={handleRefresh}
-            disabled={isRefreshing}
-            className={`tech-button px-3 py-1 text-xs ${
-              isRefreshing ? "opacity-50 cursor-not-allowed" : ""
-            }`}
-          >
-            {isRefreshing ? "REFRESHING..." : "REFRESH"}
-          </button>
-          {lastUpdated && (
-            <div className="text-xs text-gray-500 mt-1">
-              Updated: {lastUpdated.toLocaleTimeString()}
-            </div>
-          )}
-        </div>
-      </div>
+      <SectionHeader />
 
       {nextRace && (
         <div className="mb-6 tech-card tech-corner tech-scan">

--- a/src/hooks/useFetchData.js
+++ b/src/hooks/useFetchData.js
@@ -1,0 +1,44 @@
+import { useState, useCallback, useEffect, useRef } from "react";
+
+export const useFetchData = (fetchFn, validate) => {
+  const [data, setData] = useState(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState(null);
+  const [refreshing, setRefreshing] = useState(false);
+  const [lastUpdated, setLastUpdated] = useState(null);
+
+  // Use refs so `load` stays stable while always calling the latest fetchFn/validate
+  const fetchRef = useRef(fetchFn);
+  fetchRef.current = fetchFn;
+  const validateRef = useRef(validate);
+  validateRef.current = validate;
+
+  const load = useCallback(async (isRefresh = false) => {
+    isRefresh ? setRefreshing(true) : setLoading(true);
+    try {
+      const result = await fetchRef.current();
+      if (result === "No Data Fetched") {
+        setError("No Data Fetched");
+        setData(null);
+      } else if (!validateRef.current || validateRef.current(result)) {
+        setData(result);
+        setError(null);
+        setLastUpdated(new Date());
+      } else {
+        setError("Invalid data format received");
+        setData(null);
+      }
+    } catch {
+      setError("Failed to load data");
+      setData(null);
+    } finally {
+      isRefresh ? setRefreshing(false) : setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    load();
+  }, [load]);
+
+  return { data, loading, error, refreshing, lastUpdated, refresh: () => load(true) };
+};

--- a/src/utils/raceUtils.js
+++ b/src/utils/raceUtils.js
@@ -1,0 +1,64 @@
+export const formatDate = (dateString, timeString) => {
+  try {
+    if (!dateString) return "TBD";
+    const date =
+      timeString && !dateString.includes("T")
+        ? new Date(`${dateString}T${timeString}`)
+        : new Date(dateString);
+    return new Intl.DateTimeFormat("en-GB", {
+      day: "numeric",
+      month: "short",
+      year: "numeric",
+    }).format(date);
+  } catch {
+    return "Date TBD";
+  }
+};
+
+export const formatTime = (dateString, timeString) => {
+  try {
+    if (!dateString) return "";
+    if (!timeString && !dateString.includes("T")) return "";
+    const date = dateString.includes("T")
+      ? new Date(dateString)
+      : new Date(`${dateString}T${timeString}`);
+    return new Intl.DateTimeFormat("en-GB", {
+      hour: "2-digit",
+      minute: "2-digit",
+    }).format(date);
+  } catch {
+    return "";
+  }
+};
+
+export const isPastRace = (dateString) => {
+  if (!dateString) return false;
+  try {
+    return new Date(dateString) < new Date();
+  } catch {
+    return false;
+  }
+};
+
+export const getDaysUntilRace = (raceDate) => {
+  const diffMs = Math.abs(new Date(raceDate) - new Date());
+  return Math.ceil(diffMs / (1000 * 60 * 60 * 24));
+};
+
+export const getNextRace = (races) => {
+  const today = new Date();
+  return races.find((race) => new Date(race.date) > today) ?? null;
+};
+
+export const groupRacesByMonth = (races) =>
+  races.reduce((acc, race) => {
+    try {
+      const month = new Date(race.date).toLocaleString("default", {
+        month: "long",
+      });
+      (acc[month] ??= []).push(race);
+    } catch {
+      (acc["Unknown"] ??= []).push(race);
+    }
+    return acc;
+  }, {});

--- a/src/utils/teamColors.js
+++ b/src/utils/teamColors.js
@@ -1,0 +1,51 @@
+const TEAM_COLORS = {
+  // Current teams (precise hex)
+  "Red Bull":          { hex: "#0600EF", text: "text-[#0600EF]" },
+  Ferrari:             { hex: "#DC0000", text: "text-[#DC0000]" },
+  Mercedes:            { hex: "#00D2BE", text: "text-[#00D2BE]" },
+  McLaren:             { hex: "#FF8700", text: "text-[#FF8700]" },
+  "Aston Martin":      { hex: "#006F62", text: "text-[#006F62]" },
+  Alpine:              { hex: "#0090FF", text: "text-[#0090FF]" },
+  Williams:            { hex: "#005AFF", text: "text-[#005AFF]" },
+  AlphaTauri:          { hex: "#2B4562", text: "text-[#2B4562]" },
+  "Alfa Romeo":        { hex: "#900000", text: "text-[#900000]" },
+  Haas:                { hex: "#FFFFFF", text: "text-white" },
+  "Haas F1 Team":      { hex: "#FFFFFF", text: "text-white" },
+  RB:                  { hex: "#0600EF", text: "text-[#0600EF]" },
+  "Racing Bulls":      { hex: "#0600EF", text: "text-[#0600EF]" },
+  "Visa Cash App RB":  { hex: "#0600EF", text: "text-[#0600EF]" },
+  VCARB:               { hex: "#0600EF", text: "text-[#0600EF]" },
+  Sauber:              { hex: "#900000", text: "text-[#900000]" },
+  "Stake F1 Team":     { hex: "#900000", text: "text-[#900000]" },
+  "Stake F1":          { hex: "#900000", text: "text-[#900000]" },
+  // Historical teams
+  "Racing Point":      { hex: "#F596C8", text: "text-pink-400" },
+  Renault:             { hex: "#FFF500", text: "text-yellow-400" },
+  "Toro Rosso":        { hex: "#469BFF", text: "text-blue-400" },
+  "Force India":       { hex: "#FF80C7", text: "text-pink-500" },
+  "Lotus F1":          { hex: "#1E1E1E", text: "text-gray-200" },
+  Marussia:            { hex: "#EF0000", text: "text-red-500" },
+  Caterham:            { hex: "#0C5E00", text: "text-green-600" },
+  HRT:                 { hex: "#555555", text: "text-gray-500" },
+  Virgin:              { hex: "#CC0000", text: "text-red-400" },
+  "Brawn GP":          { hex: "#80FF00", text: "text-green-400" },
+  Toyota:              { hex: "#CC1C11", text: "text-red-400" },
+  "Super Aguri":       { hex: "#FFFFFF", text: "text-white" },
+  Spyker:              { hex: "#E8640F", text: "text-orange-500" },
+  Midland:             { hex: "#CC0000", text: "text-red-300" },
+  Minardi:             { hex: "#1A1A1A", text: "text-gray-300" },
+  Jaguar:              { hex: "#006A11", text: "text-green-700" },
+  BAR:                 { hex: "#FFFFFF", text: "text-white" },
+  Jordan:              { hex: "#FFB800", text: "text-yellow-500" },
+  Arrows:              { hex: "#C25B00", text: "text-orange-600" },
+  Prost:               { hex: "#4A90D9", text: "text-blue-400" },
+  Benetton:            { hex: "#22AA00", text: "text-green-400" },
+  Stewart:             { hex: "#FFFFFF", text: "text-white" },
+  Tyrrell:             { hex: "#4A90D9", text: "text-blue-300" },
+};
+
+export const getTeamHexColor = (teamName) =>
+  TEAM_COLORS[teamName]?.hex ?? "#6B7280";
+
+export const getTeamTextClass = (teamName) =>
+  TEAM_COLORS[teamName]?.text ?? "text-gray-400";


### PR DESCRIPTION
## Summary

- **`useFetchData` hook** — eliminates the identical `loading/refreshing/error/lastUpdated` state + fetch lifecycle pattern that was copy-pasted across all 3 components
- **`utils/teamColors.js`** — merges two separate duplicate team color maps (from `DriverStandings` and `LastRaceResults`) into one source of truth
- **`utils/raceUtils.js`** — extracts `formatDate`, `formatTime`, `isPastRace`, `getDaysUntilRace`, `getNextRace`, `groupRacesByMonth` from inline functions in `RaceSchedule`
- **`f1Service.js`** — deduplicates `transformRace` (was copy-pasted 3×), replaces nested try/catch URL fallbacks with a clean URL loop, extracts `withYearFallback`, removes ~40 debug `console.log` calls
- **Bug fix** — `DriverStandings` team color bar was passing a Tailwind class string (e.g. `"bg-[#0600EF]"`) as an inline `backgroundColor` value; now correctly uses hex colors via `getTeamHexColor()`
- **Bug fix** — `LastRaceResults` was fetching the last *scheduled* round (Abu Dhabi) instead of the last *completed* race; fixed by using the `/last/` Ergast API endpoint
- **Dead code removed** — `viewAll` state and `displayedResults` in `LastRaceResults` were computed but never referenced in JSX
- **Favicon** — replaced default Vite SVG with an F1-themed icon matching the app's dark/red aesthetic

## Test plan

- [ ] Driver standings load and display correctly
- [ ] Race schedule shows upcoming races with correct next race highlighted
- [ ] Last race results shows the most recently completed race (not the last scheduled round)
- [ ] Team color bars render correctly in driver standings table
- [ ] Refresh buttons work on all sections
- [ ] Favicon shows in browser tab

🤖 Generated with [Claude Code](https://claude.com/claude-code)