### PR TITLE
rebrand: F1Pulse rename + SEO

### DIFF
--- a/index.html
+++ b/index.html
@@ -2,9 +2,53 @@
 <html lang="en">
   <head>
     <meta charset="UTF-8" />
-    <link rel="icon" type="image/svg+xml" href="/f1pulse.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>F1Pulse</title>
+    <link rel="icon" type="image/svg+xml" href="/f1pulse.svg" />
+    <title>F1Pulse — Real-Time Formula 1 Data Dashboard</title>
+
+    <!-- Primary Meta -->
+    <meta name="description" content="F1Pulse is a real-time Formula 1 data dashboard. Live driver standings, race schedule, lap-by-lap results, constructor standings and live session timing — all in one place." />
+    <meta name="keywords" content="Formula 1, F1, F1 standings, F1 schedule, F1 results, F1 live timing, Formula 1 dashboard, F1 data, constructor standings, F1 2026" />
+    <meta name="author" content="F1Pulse" />
+    <link rel="canonical" href="https://formula1-hub.vercel.app/" />
+
+    <!-- Open Graph -->
+    <meta property="og:type" content="website" />
+    <meta property="og:url" content="https://formula1-hub.vercel.app/" />
+    <meta property="og:title" content="F1Pulse — Real-Time Formula 1 Data Dashboard" />
+    <meta property="og:description" content="Live driver standings, race schedule, lap-by-lap results, constructor standings and live session timing for Formula 1." />
+    <meta property="og:image" content="https://formula1-hub.vercel.app/og-image.png" />
+    <meta property="og:site_name" content="F1Pulse" />
+
+    <!-- Twitter Card -->
+    <meta name="twitter:card" content="summary_large_image" />
+    <meta name="twitter:url" content="https://formula1-hub.vercel.app/" />
+    <meta name="twitter:title" content="F1Pulse — Real-Time Formula 1 Data Dashboard" />
+    <meta name="twitter:description" content="Live driver standings, race schedule, lap-by-lap results, constructor standings and live session timing for Formula 1." />
+    <meta name="twitter:image" content="https://formula1-hub.vercel.app/og-image.png" />
+
+    <!-- JSON-LD Structured Data -->
+    <script type="application/ld+json">
+    {
+      "@context": "https://schema.org",
+      "@type": "WebApplication",
+      "name": "F1Pulse",
+      "url": "https://formula1-hub.vercel.app",
+      "description": "Real-time Formula 1 data dashboard with live standings, race schedule, results and timing.",
+      "applicationCategory": "SportsApplication",
+      "operatingSystem": "Any",
+      "offers": {
+        "@type": "Offer",
+        "price": "0",
+        "priceCurrency": "USD"
+      },
+      "about": {
+        "@type": "SportsOrganization",
+        "name": "Formula 1",
+        "sport": "Motorsport"
+      }
+    }
+    </script>
   </head>
   <body>
     <div id="root"></div>

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "dependencies": {
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
+        "react-helmet-async": "^3.0.0",
         "react-router-dom": "^7.13.1",
         "recharts": "^3.8.0"
       },
@@ -4972,6 +4973,15 @@
         "node": ">=12"
       }
     },
+    "node_modules/invariant": {
+      "version": "2.2.4",
+      "resolved": "https://registry.npmjs.org/invariant/-/invariant-2.2.4.tgz",
+      "integrity": "sha512-phJfQVBuaJM5raOpJjSfkiD6BpbCE4Ns//LaXl6wGYtUBY83nWS6Rf9tXm2e8VaK60JEjYldbPif/A2B1C2gNA==",
+      "license": "MIT",
+      "dependencies": {
+        "loose-envify": "^1.0.0"
+      }
+    },
     "node_modules/is-array-buffer": {
       "version": "3.0.5",
       "resolved": "https://registry.npmjs.org/is-array-buffer/-/is-array-buffer-3.0.5.tgz",
@@ -6382,6 +6392,26 @@
         "react": "^18.3.1"
       }
     },
+    "node_modules/react-fast-compare": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/react-fast-compare/-/react-fast-compare-3.2.2.tgz",
+      "integrity": "sha512-nsO+KSNgo1SbJqJEYRE9ERzo7YtYbou/OqjSQKxV7jcKox7+usiUVZOAC+XnDOABXggQTno0Y1CpVnuWEc1boQ==",
+      "license": "MIT"
+    },
+    "node_modules/react-helmet-async": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/react-helmet-async/-/react-helmet-async-3.0.0.tgz",
+      "integrity": "sha512-nA3IEZfXiclgrz4KLxAhqJqIfFDuvzQwlKwpdmzZIuC1KNSghDEIXmyU0TKtbM+NafnkICcwx8CECFrZ/sL/1w==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "invariant": "^2.2.4",
+        "react-fast-compare": "^3.2.2",
+        "shallowequal": "^1.1.0"
+      },
+      "peerDependencies": {
+        "react": "^16.6.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
     "node_modules/react-is": {
       "version": "19.2.4",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-19.2.4.tgz",
@@ -6927,6 +6957,12 @@
       "engines": {
         "node": ">= 0.4"
       }
+    },
+    "node_modules/shallowequal": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/shallowequal/-/shallowequal-1.1.0.tgz",
+      "integrity": "sha512-y0m1JoUZSlPAjXVtPPW70aZWfIL/dSP7AFkRnniLCrK/8MDKog3TySTBmckD+RObVxH0v4Tox67+F14PdED2oQ==",
+      "license": "MIT"
     },
     "node_modules/shebang-command": {
       "version": "2.0.0",

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
   "dependencies": {
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
+    "react-helmet-async": "^3.0.0",
     "react-router-dom": "^7.13.1",
     "recharts": "^3.8.0"
   },

--- a/public/og-image.svg
+++ b/public/og-image.svg
@@ -1,0 +1,8 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1200" height="630" viewBox="0 0 1200 630">
+  <rect width="1200" height="630" fill="#080A0F"/>
+  <rect x="0" y="0" width="1200" height="4" fill="#DC0000"/>
+  <rect x="0" y="626" width="1200" height="4" fill="#DC0000"/>
+  <text x="600" y="260" font-family="monospace" font-weight="bold" font-size="96" fill="#DC0000" text-anchor="middle">F1PULSE</text>
+  <text x="600" y="340" font-family="monospace" font-size="28" fill="#9CA3AF" text-anchor="middle">Real-Time Formula 1 Data Dashboard</text>
+  <text x="600" y="400" font-family="monospace" font-size="20" fill="#DC0000" text-anchor="middle" opacity="0.7">STANDINGS • SCHEDULE • RESULTS • LIVE TIMING</text>
+</svg>

--- a/public/robots.txt
+++ b/public/robots.txt
@@ -1,0 +1,4 @@
+User-agent: *
+Allow: /
+
+Sitemap: https://formula1-hub.vercel.app/sitemap.xml

--- a/public/sitemap.xml
+++ b/public/sitemap.xml
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+  <url>
+    <loc>https://formula1-hub.vercel.app/</loc>
+    <changefreq>daily</changefreq>
+    <priority>1.0</priority>
+  </url>
+  <url>
+    <loc>https://formula1-hub.vercel.app/standings</loc>
+    <changefreq>weekly</changefreq>
+    <priority>0.9</priority>
+  </url>
+  <url>
+    <loc>https://formula1-hub.vercel.app/constructors</loc>
+    <changefreq>weekly</changefreq>
+    <priority>0.8</priority>
+  </url>
+  <url>
+    <loc>https://formula1-hub.vercel.app/schedule</loc>
+    <changefreq>weekly</changefreq>
+    <priority>0.9</priority>
+  </url>
+  <url>
+    <loc>https://formula1-hub.vercel.app/results</loc>
+    <changefreq>weekly</changefreq>
+    <priority>0.8</priority>
+  </url>
+</urlset>

--- a/src/components/SEO.tsx
+++ b/src/components/SEO.tsx
@@ -1,0 +1,32 @@
+import { Helmet } from 'react-helmet-async';
+
+interface SEOProps {
+  title?: string;
+  description?: string;
+  path?: string;
+}
+
+const BASE_URL = 'https://formula1-hub.vercel.app';
+const DEFAULT_TITLE = 'F1Pulse — Real-Time Formula 1 Data Dashboard';
+const DEFAULT_DESC = 'Live driver standings, race schedule, results, constructor standings and live timing for Formula 1.';
+
+const SEO = ({ title, description, path = '' }: SEOProps) => {
+  const fullTitle = title ? `${title} | F1Pulse` : DEFAULT_TITLE;
+  const desc = description ?? DEFAULT_DESC;
+  const url = `${BASE_URL}${path}`;
+
+  return (
+    <Helmet>
+      <title>{fullTitle}</title>
+      <meta name="description" content={desc} />
+      <link rel="canonical" href={url} />
+      <meta property="og:title" content={fullTitle} />
+      <meta property="og:description" content={desc} />
+      <meta property="og:url" content={url} />
+      <meta name="twitter:title" content={fullTitle} />
+      <meta name="twitter:description" content={desc} />
+    </Helmet>
+  );
+};
+
+export default SEO;

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,10 +1,13 @@
 import { StrictMode } from 'react'
 import { createRoot } from 'react-dom/client'
+import { HelmetProvider } from 'react-helmet-async'
 import './index.css'
 import App from './App'
 
 createRoot(document.getElementById('root')!).render(
   <StrictMode>
-    <App />
+    <HelmetProvider>
+      <App />
+    </HelmetProvider>
   </StrictMode>,
 )

--- a/src/pages/Constructors.tsx
+++ b/src/pages/Constructors.tsx
@@ -1,4 +1,5 @@
 import { lazy, Suspense } from "react";
+import SEO from "../components/SEO";
 
 const ConstructorStandings = lazy(
   () => import("../components/ConstructorStandings")
@@ -16,13 +17,20 @@ const CardSkeleton = () => (
 );
 
 const Constructors = () => (
-  <div className="w-full px-4 py-12 pt-24">
-    <div className="max-w-[1920px] mx-auto">
-      <Suspense fallback={<CardSkeleton />}>
-        <ConstructorStandings />
-      </Suspense>
+  <>
+    <SEO
+      title="Constructor Standings"
+      description="Current F1 constructor championship standings."
+      path="/constructors"
+    />
+    <div className="w-full px-4 py-12 pt-24">
+      <div className="max-w-[1920px] mx-auto">
+        <Suspense fallback={<CardSkeleton />}>
+          <ConstructorStandings />
+        </Suspense>
+      </div>
     </div>
-  </div>
+  </>
 );
 
 export default Constructors;

--- a/src/pages/Dashboard.tsx
+++ b/src/pages/Dashboard.tsx
@@ -1,5 +1,6 @@
 import { lazy, Suspense } from "react";
 import LiveTiming from "../components/LiveTiming";
+import SEO from "../components/SEO";
 
 const LastRaceResults = lazy(() => import("../components/LastRaceResults"));
 const DriverStandings = lazy(() => import("../components/DriverStandings"));
@@ -20,6 +21,7 @@ const CardSkeleton = () => (
 const Dashboard = () => {
   return (
     <>
+      <SEO path="/" />
       {/* Hero */}
       <div className="relative overflow-hidden w-full">
         <div className="absolute inset-0 bg-[url('/f1-hero.jpg')] bg-cover bg-center opacity-10"></div>

--- a/src/pages/RaceDetail.tsx
+++ b/src/pages/RaceDetail.tsx
@@ -4,6 +4,7 @@ import { getRaceResults, getQualifyingResults } from "../api/f1Service";
 import { useFetchData } from "../hooks/useFetchData";
 import { getTeamHexColor, getTeamTextClass } from "../utils/teamColors";
 import type { LastRaceData, QualifyingResult } from "../types/f1";
+import SEO from "../components/SEO";
 
 const positionClass = (index: number): string => {
   if (index === 0) return "border-yellow-500 text-yellow-500";
@@ -80,6 +81,11 @@ const RaceDetail = () => {
 
   return (
     <div className="w-full px-4 py-12 pt-24">
+      <SEO
+        title={raceData.raceName}
+        description={`Full results for the ${raceData.raceName} at ${raceData.Circuit?.circuitName}.`}
+        path={`/race/${season}/${round}`}
+      />
       <div className="max-w-5xl mx-auto">
         {/* Back link */}
         <Link

--- a/src/pages/Results.tsx
+++ b/src/pages/Results.tsx
@@ -1,4 +1,5 @@
 import { lazy, Suspense } from "react";
+import SEO from "../components/SEO";
 
 const LastRaceResults = lazy(() => import("../components/LastRaceResults"));
 
@@ -14,13 +15,20 @@ const CardSkeleton = () => (
 );
 
 const Results = () => (
-  <div className="w-full px-4 py-12 pt-24">
-    <div className="max-w-[1920px] mx-auto">
-      <Suspense fallback={<CardSkeleton />}>
-        <LastRaceResults />
-      </Suspense>
+  <>
+    <SEO
+      title="Last Race Results"
+      description="Latest Formula 1 race results including podium, fastest lap and full classification."
+      path="/results"
+    />
+    <div className="w-full px-4 py-12 pt-24">
+      <div className="max-w-[1920px] mx-auto">
+        <Suspense fallback={<CardSkeleton />}>
+          <LastRaceResults />
+        </Suspense>
+      </div>
     </div>
-  </div>
+  </>
 );
 
 export default Results;

--- a/src/pages/Schedule.tsx
+++ b/src/pages/Schedule.tsx
@@ -1,4 +1,5 @@
 import { lazy, Suspense } from "react";
+import SEO from "../components/SEO";
 
 const RaceSchedule = lazy(() => import("../components/RaceSchedule"));
 
@@ -14,13 +15,20 @@ const ScheduleSkeleton = () => (
 );
 
 const Schedule = () => (
-  <div className="w-full px-4 py-12 pt-24">
-    <div className="max-w-4xl mx-auto">
-      <Suspense fallback={<ScheduleSkeleton />}>
-        <RaceSchedule fullPage />
-      </Suspense>
+  <>
+    <SEO
+      title="Race Schedule"
+      description="Full Formula 1 race calendar with dates, circuits and locations."
+      path="/schedule"
+    />
+    <div className="w-full px-4 py-12 pt-24">
+      <div className="max-w-4xl mx-auto">
+        <Suspense fallback={<ScheduleSkeleton />}>
+          <RaceSchedule fullPage />
+        </Suspense>
+      </div>
     </div>
-  </div>
+  </>
 );
 
 export default Schedule;

--- a/src/pages/Standings.tsx
+++ b/src/pages/Standings.tsx
@@ -1,4 +1,5 @@
 import { lazy, Suspense } from "react";
+import SEO from "../components/SEO";
 
 const DriverStandings = lazy(() => import("../components/DriverStandings"));
 const ChampionshipChart = lazy(() => import("../components/ChampionshipChart"));
@@ -15,16 +16,23 @@ const CardSkeleton = () => (
 );
 
 const Standings = () => (
-  <div className="w-full px-4 py-12 pt-24">
-    <div className="max-w-[1920px] mx-auto">
-      <Suspense fallback={<CardSkeleton />}>
-        <DriverStandings />
-      </Suspense>
-      <Suspense fallback={<CardSkeleton />}>
-        <ChampionshipChart />
-      </Suspense>
+  <>
+    <SEO
+      title="Driver Standings"
+      description="Current F1 driver championship standings with points, wins and team data."
+      path="/standings"
+    />
+    <div className="w-full px-4 py-12 pt-24">
+      <div className="max-w-[1920px] mx-auto">
+        <Suspense fallback={<CardSkeleton />}>
+          <DriverStandings />
+        </Suspense>
+        <Suspense fallback={<CardSkeleton />}>
+          <ChampionshipChart />
+        </Suspense>
+      </div>
     </div>
-  </div>
+  </>
 );
 
 export default Standings;


### PR DESCRIPTION
## Summary

### Rebrand
- App renamed from Formula 1 Hub → **F1Pulse** everywhere (title, header, footer, hero, PWA manifest, package.json)
- Favicon renamed `f1hub.svg` → `f1pulse.svg`

### SEO
- Full meta tags, Open Graph, Twitter Card, JSON-LD structured data in `index.html`
- `public/robots.txt` — allows all crawlers, points to sitemap
- `public/sitemap.xml` — all 5 routes with priority/frequency hints
- `public/og-image.svg` — 1200×630 social preview image
- `src/components/SEO.tsx` — reusable per-page SEO via `react-helmet-async`
- Unique `<title>` and `<meta description>` on every page

### All previous features (PRs #2–#5)
TypeScript, caching, routing, error boundaries, skeletons, constructor standings, season selector, race detail, qualifying tab, PWA, search/filter, championship chart, live timing, GitHub Actions CI

## Test plan
- [ ] Tab title shows correct page name on each route
- [ ] Sharing a link shows F1Pulse OG preview
- [ ] `formula1-hub.vercel.app/robots.txt` returns the robots file
- [ ] `formula1-hub.vercel.app/sitemap.xml` returns the sitemap

🤖 Generated with [Claude Code](https://claude.com/claude-code)