### PR TITLE
feat: add Vercel Speed Insights

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.0.0",
       "dependencies": {
         "@vercel/analytics": "^2.0.0",
+        "@vercel/speed-insights": "^2.0.0",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
         "react-helmet-async": "^3.0.0",
@@ -6573,6 +6574,44 @@
       "peer": true,
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/@vercel/speed-insights": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@vercel/speed-insights/-/speed-insights-2.0.0.tgz",
+      "integrity": "sha512-jwkNcrTeafWxjmWq4AHBaptSqZiJkYU5adLC9QBSqeim0GcqDMgN5Ievh8OG1rJ6W3A4l1oiP7qr9CWxGuzu3w==",
+      "license": "Apache-2.0",
+      "peerDependencies": {
+        "@sveltejs/kit": "^1 || ^2",
+        "next": ">= 13",
+        "nuxt": ">= 3",
+        "react": "^18 || ^19 || ^19.0.0-rc",
+        "svelte": ">= 4",
+        "vue": "^3",
+        "vue-router": "^4"
+      },
+      "peerDependenciesMeta": {
+        "@sveltejs/kit": {
+          "optional": true
+        },
+        "next": {
+          "optional": true
+        },
+        "nuxt": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        },
+        "svelte": {
+          "optional": true
+        },
+        "vue": {
+          "optional": true
+        },
+        "vue-router": {
+          "optional": true
+        }
       }
     },
     "node_modules/@vite-pwa/assets-generator": {

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
   },
   "dependencies": {
     "@vercel/analytics": "^2.0.0",
+    "@vercel/speed-insights": "^2.0.0",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "react-helmet-async": "^3.0.0",

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -2,6 +2,7 @@ import { StrictMode } from 'react'
 import { createRoot } from 'react-dom/client'
 import { HelmetProvider } from 'react-helmet-async'
 import { Analytics } from '@vercel/analytics/react'
+import { SpeedInsights } from '@vercel/speed-insights/react'
 import './index.css'
 import App from './App'
 
@@ -11,5 +12,6 @@ createRoot(document.getElementById('root')!).render(
       <App />
     </HelmetProvider>
     <Analytics />
+    <SpeedInsights />
   </StrictMode>,
 )


### PR DESCRIPTION
## Summary
- Install `@vercel/speed-insights` package
- Add `<SpeedInsights />` component to `src/main.tsx` to collect performance metrics

## Test plan
- [ ] Deploy to Vercel
- [ ] Visit the site and navigate between pages
- [ ] Confirm performance data appears in Vercel Speed Insights dashboard within ~30 seconds

🤖 Generated with [Claude Code](https://claude.com/claude-code)