### PR TITLE
fix: update page title and meta description

### DIFF
--- a/index.html
+++ b/index.html
@@ -10,27 +10,27 @@
     <meta name="apple-mobile-web-app-capable" content="yes">
     <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent">
     <meta name="apple-mobile-web-app-title" content="F1Pulse">
-    <title>F1Pulse — Real-Time Formula 1 Data Dashboard</title>
+    <title>F1Pulse — Formula 1 Data & Statistics</title>
 
     <!-- Primary Meta -->
-    <meta name="description" content="F1Pulse is a real-time Formula 1 data dashboard. Live driver standings, race schedule, lap-by-lap results, constructor standings and live session timing — all in one place." />
-    <meta name="keywords" content="Formula 1, F1, F1 standings, F1 schedule, F1 results, F1 live timing, Formula 1 dashboard, F1 data, constructor standings, F1 2026" />
+    <meta name="description" content="Formula 1 data & statistics interface. Access race results, driver statistics, and circuit analytics." />
+    <meta name="keywords" content="Formula 1, F1, F1 standings, F1 schedule, F1 results, F1 data, driver statistics, circuit analytics, constructor standings, F1 2026" />
     <meta name="author" content="F1Pulse" />
     <link rel="canonical" href="https://formula1-hub.vercel.app/" />
 
     <!-- Open Graph -->
     <meta property="og:type" content="website" />
     <meta property="og:url" content="https://formula1-hub.vercel.app/" />
-    <meta property="og:title" content="F1Pulse — Real-Time Formula 1 Data Dashboard" />
-    <meta property="og:description" content="Live driver standings, race schedule, lap-by-lap results, constructor standings and live session timing for Formula 1." />
+    <meta property="og:title" content="F1Pulse — Formula 1 Data & Statistics" />
+    <meta property="og:description" content="Formula 1 data & statistics interface. Access race results, driver statistics, and circuit analytics." />
     <meta property="og:image" content="https://formula1-hub.vercel.app/og-image.png" />
     <meta property="og:site_name" content="F1Pulse" />
 
     <!-- Twitter Card -->
     <meta name="twitter:card" content="summary_large_image" />
     <meta name="twitter:url" content="https://formula1-hub.vercel.app/" />
-    <meta name="twitter:title" content="F1Pulse — Real-Time Formula 1 Data Dashboard" />
-    <meta name="twitter:description" content="Live driver standings, race schedule, lap-by-lap results, constructor standings and live session timing for Formula 1." />
+    <meta name="twitter:title" content="F1Pulse — Formula 1 Data & Statistics" />
+    <meta name="twitter:description" content="Formula 1 data & statistics interface. Access race results, driver statistics, and circuit analytics." />
     <meta name="twitter:image" content="https://formula1-hub.vercel.app/og-image.png" />
 
     <!-- JSON-LD Structured Data -->
@@ -40,7 +40,7 @@
       "@type": "WebApplication",
       "name": "F1Pulse",
       "url": "https://formula1-hub.vercel.app",
-      "description": "Real-time Formula 1 data dashboard with live standings, race schedule, results and timing.",
+      "description": "Formula 1 data & statistics interface. Access race results, driver statistics, and circuit analytics.",
       "applicationCategory": "SportsApplication",
       "operatingSystem": "Any",
       "offers": {

--- a/src/components/SEO.tsx
+++ b/src/components/SEO.tsx
@@ -7,11 +7,11 @@ interface SEOProps {
 }
 
 const BASE_URL = 'https://formula1-hub.vercel.app';
-const DEFAULT_TITLE = 'F1Pulse — Real-Time Formula 1 Data Dashboard';
-const DEFAULT_DESC = 'Live driver standings, race schedule, results, constructor standings and live timing for Formula 1.';
+const DEFAULT_TITLE = 'F1Pulse — Formula 1 Data & Statistics';
+const DEFAULT_DESC = 'Formula 1 data & statistics interface. Access race results, driver statistics, and circuit analytics.';
 
 const SEO = ({ title, description, path = '' }: SEOProps) => {
-  const fullTitle = title ? `${title} | F1Pulse` : DEFAULT_TITLE;
+  const fullTitle = title ? `${title} — F1Pulse` : DEFAULT_TITLE;
   const desc = description ?? DEFAULT_DESC;
   const url = `${BASE_URL}${path}`;
 


### PR DESCRIPTION
## Summary
- Updates `<title>` from "F1Pulse — Real-Time Formula 1 Data Dashboard" to "F1Pulse — Formula 1 Data & Statistics"
- Updates meta description, OG, Twitter, and JSON-LD descriptions to: "Formula 1 data & statistics interface. Access race results, driver statistics, and circuit analytics."
- Same changes applied in both `index.html` (static/SSG) and `src/components/SEO.tsx` (runtime via react-helmet-async)

## Test plan
- [ ] Verify browser tab shows new title
- [ ] Check OG preview (e.g. via opengraph.xyz) reflects new title/description

🤖 Generated with [Claude Code](https://claude.com/claude-code)