### PR TITLE
fix: relax race schedule validation for incomplete circuit location data

### DIFF
--- a/src/api/f1Service.ts
+++ b/src/api/f1Service.ts
@@ -56,7 +56,7 @@ const withYearFallback = <T>(
 
 const transformRace = (race: Record<string, unknown>): Race => {
   const circuit = race.Circuit as Record<string, unknown>;
-  const location = circuit.Location as Record<string, unknown>;
+  const location = circuit?.Location as Record<string, unknown> | undefined;
   return {
     season: parseInt(race.season as string),
     round: parseInt(race.round as string),
@@ -66,10 +66,12 @@ const transformRace = (race: Record<string, unknown>): Race => {
     Circuit: {
       circuitId: circuit.circuitId as string,
       circuitName: circuit.circuitName as string,
-      Location: {
-        locality: location.locality as string,
-        country: location.country as string,
-      },
+      Location: location
+        ? {
+            locality: location.locality as string | undefined,
+            country: location.country as string | undefined,
+          }
+        : undefined,
     },
     hasSprint: !!race.Sprint,
   };

--- a/src/components/RaceSchedule.tsx
+++ b/src/components/RaceSchedule.tsx
@@ -23,9 +23,7 @@ const validateRaces = (races: Race[]): boolean =>
       r?.round &&
       r?.raceName &&
       r?.date &&
-      r?.Circuit?.circuitName &&
-      r?.Circuit?.Location?.locality &&
-      r?.Circuit?.Location?.country
+      r?.Circuit?.circuitName
   );
 
 interface RaceScheduleProps {
@@ -196,9 +194,9 @@ const RaceSchedule = ({ fullPage }: RaceScheduleProps) => {
                 />
               </svg>
               <span className="tech-text text-xs tracking-wider">
-                {nextRace.Circuit.circuitName},{" "}
-                {nextRace.Circuit.Location.locality},{" "}
-                {nextRace.Circuit.Location.country}
+                {nextRace.Circuit.circuitName}
+                {nextRace.Circuit.Location?.locality ? `, ${nextRace.Circuit.Location.locality}` : ""}
+                {nextRace.Circuit.Location?.country ? `, ${nextRace.Circuit.Location.country}` : ""}
               </span>
             </div>
 

--- a/src/types/f1.ts
+++ b/src/types/f1.ts
@@ -21,14 +21,14 @@ export interface DriverStanding {
 }
 
 export interface CircuitLocation {
-  locality: string;
-  country: string;
+  locality?: string;
+  country?: string;
 }
 
 export interface Circuit {
   circuitId: string;
   circuitName: string;
-  Location: CircuitLocation;
+  Location?: CircuitLocation;
 }
 
 export interface Race {


### PR DESCRIPTION
## Summary
- The 2026 race calendar was showing \"Invalid data format received\" because some races in the API response were missing `Circuit.Location.locality` or `Circuit.Location.country`
- Removed `locality` and `country` from the required validation fields (only `circuitName` is now required)
- Made `Circuit.Location`, `locality`, and `country` optional in the TypeScript types
- Updated `transformRace` and the schedule display to safely handle missing location values

## Test plan
- [ ] Visit the Race Calendar section — should now display 2026 races instead of the error state
- [ ] Verify the \"Next Race\" panel still shows circuit info (with location if available)
- [ ] Verify past-season fallback still works if 2026 data is unavailable

🤖 Generated with [Claude Code](https://claude.com/claude-code)