### PR TITLE
fix: filter races missing round field from Jolpica API

### DIFF
--- a/src/api/f1Service.ts
+++ b/src/api/f1Service.ts
@@ -198,11 +198,15 @@ export const getDriverStandings = async (
 
 // Tries axios first, then iterates through fallback URLs (proxy → direct).
 const fetchRaceScheduleRaw = async (season: number): Promise<Race[] | null> => {
+  const toRaces = (raw: Record<string, unknown>[]) =>
+    raw.filter((r) => r.round != null).map((r) => transformRace(r));
+
   try {
     const response = await jolpicaInstance.get(`f1/${season}.json`);
     const races = response.data?.MRData?.RaceTable?.Races;
     if (races?.length > 0) {
-      return races.map((r: Record<string, unknown>) => transformRace(r));
+      const mapped = toRaces(races);
+      if (mapped.length > 0) return mapped;
     }
   } catch (_) {}
 
@@ -220,7 +224,8 @@ const fetchRaceScheduleRaw = async (season: number): Promise<Race[] | null> => {
       const data = await res.json();
       const races = data?.MRData?.RaceTable?.Races;
       if (races?.length > 0) {
-        return races.map((r: Record<string, unknown>) => transformRace(r));
+        const mapped = toRaces(races);
+        if (mapped.length > 0) return mapped;
       }
     } catch (_) {}
   }


### PR DESCRIPTION
## Summary
- The previous PR fixed types and display but the core fix didn't make it into main
- The 2026 Jolpica API returns Bahrain GP and Saudi Arabian GP **without a `round` field**
- `parseInt(undefined) = NaN` → falsy → `races.every(r => r?.round && ...)` fails → entire calendar shows "Invalid data format received"
- Filters out any races with `round == null` before mapping, so the 22 valid races are returned cleanly

## Test plan
- [ ] Race Calendar should display the 22 rounds of the 2026 season
- [ ] No more "Invalid data format received" error

🤖 Generated with [Claude Code](https://claude.com/claude-code)