### PR TITLE
fix: evict stale cached race data with invalid round fields

### DIFF
--- a/src/api/f1Service.ts
+++ b/src/api/f1Service.ts
@@ -238,7 +238,11 @@ export const getRaceSchedule = async (
 ): Promise<Race[] | null> => {
   const cacheKey = `f1_schedule_${season}`;
   const cached = getCached<Race[]>(cacheKey);
-  if (cached) return cached;
+  if (cached) {
+    const valid = cached.filter((r) => r.round != null && !isNaN(r.round));
+    if (valid.length > 0) return valid;
+    localStorage.removeItem(cacheKey);
+  }
 
   try {
     const races = await fetchRaceScheduleRaw(season);


### PR DESCRIPTION
## Summary
- Root cause of the persistent error: before the round-filter fix, the API response (including 2 races with `round: NaN`) was cached in localStorage
- Cached data bypasses `toRaces`, so even after deploying the fix the validator still received the old broken data
- Now cached races are filtered the same way — if all cached entries are invalid the cache key is evicted so a fresh API call is made

## Test plan
- [ ] Race Calendar loads correctly even if localStorage has old cached data
- [ ] Hard refresh on the deployed site should now show the 2026 race list

🤖 Generated with [Claude Code](https://claude.com/claude-code)