### PR TITLE
fix: use full race datetime for past/next race comparisons

### DIFF
--- a/src/components/RaceSchedule.tsx
+++ b/src/components/RaceSchedule.tsx
@@ -244,7 +244,7 @@ const RaceSchedule = ({ fullPage }: RaceScheduleProps) => {
               </h3>
               <div className="space-y-2">
                 {monthRaces.map((race) => {
-                  const past = isPastRace(race.date);
+                  const past = isPastRace(race.date, race.time);
                   const inner = (
                     <div
                       className={`p-3 flex items-center ${

--- a/src/utils/raceUtils.ts
+++ b/src/utils/raceUtils.ts
@@ -33,10 +33,13 @@ export const formatTime = (dateString: string | undefined, timeString: string | 
   }
 };
 
-export const isPastRace = (dateString: string | undefined): boolean => {
+const raceDateTime = (dateString: string, timeString?: string): Date =>
+  timeString ? new Date(`${dateString}T${timeString}`) : new Date(dateString);
+
+export const isPastRace = (dateString: string | undefined, timeString?: string): boolean => {
   if (!dateString) return false;
   try {
-    return new Date(dateString) < new Date();
+    return raceDateTime(dateString, timeString) < new Date();
   } catch {
     return false;
   }
@@ -48,8 +51,8 @@ export const getDaysUntilRace = (raceDate: string): number => {
 };
 
 export const getNextRace = (races: Race[]): Race | null => {
-  const today = new Date();
-  return races.find((race) => new Date(race.date) > today) ?? null;
+  const now = new Date();
+  return races.find((race) => raceDateTime(race.date, race.time) > now) ?? null;
 };
 
 export const groupRacesByMonth = (races: Race[]): Record<string, Race[]> =>


### PR DESCRIPTION
## Summary
- `isPastRace` and `getNextRace` only compared `race.date` (midnight), ignoring `race.time`
- On race day, the race was immediately flagged as "past" and the next race shown in the countdown — even hours before the race started
- Both functions now use `date + time` so a race is only considered past after it has actually started

## Test plan
- [ ] On race day (e.g. Chinese GP, 15 Mar 2026 at 15:00), the countdown should show that race until its start time passes
- [ ] After the race starts, it flips to past and the next race takes over

🤖 Generated with [Claude Code](https://claude.com/claude-code)